### PR TITLE
chore: Create unit tests for dragon ingester

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,6 +1246,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "dashmap",
+ "expect-test",
  "figment",
  "flatbuffers",
  "fnv",
@@ -2340,6 +2341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dissimilar"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
+
+[[package]]
 name = "dlopen2"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,6 +2558,16 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "expect-test"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0be0a561335815e06dab7c62e50353134c796e7a6155402a64bcff66b6a5e0"
+dependencies = [
+ "dissimilar",
+ "once_cell",
+]
 
 [[package]]
 name = "fallible-iterator"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -82,6 +82,7 @@ yellowstone-grpc-client = { workspace = true }
 yellowstone-grpc-proto = { workspace = true }
 
 [dev-dependencies]
+expect-test = "1.5.0"
 
 [lints]
 workspace = true

--- a/node/src/ingest/dragon.rs
+++ b/node/src/ingest/dragon.rs
@@ -188,17 +188,18 @@ fn try_send_instructions(
 
 #[cfg(test)]
 mod dragon_ingester_tests {
-    use expect_test::{expect, Expect};
-    use solana_sdk::{
-        instruction::CompiledInstruction,
-        message::{v0::Message, AccountKeys, Message as LegacyMessage, VersionedMessage},
-        pubkey::Pubkey,
-        transaction::VersionedTransaction,
+    use {
+        expect_test::{expect, Expect},
+        solana_sdk::{
+            instruction::CompiledInstruction,
+            message::{v0::Message, AccountKeys, Message as LegacyMessage, VersionedMessage},
+            pubkey::Pubkey,
+            transaction::VersionedTransaction,
+        },
+        solana_transaction_status::{InnerInstruction, InnerInstructions, TransactionStatusMeta},
     };
-    use solana_transaction_status::{InnerInstruction, InnerInstructions, TransactionStatusMeta};
 
-    use super::try_send_instructions;
-    use crate::types::BonsolInstruction;
+    use {super::try_send_instructions, crate::types::BonsolInstruction};
 
     fn check_instructions(output: &[BonsolInstruction], expect: Expect) {
         expect.assert_eq(&format!("{output:#?}"));

--- a/node/src/ingest/dragon.rs
+++ b/node/src/ingest/dragon.rs
@@ -7,7 +7,8 @@ use {
     anyhow::Result,
     futures::stream::StreamExt,
     solana_sdk::{message::VersionedMessage, pubkey::Pubkey},
-    yellowstone_grpc_client::GeyserGrpcClient,
+    tokio::sync::mpsc::UnboundedSender,
+    yellowstone_grpc_client::{GeyserGrpcBuilder, GeyserGrpcClient},
     yellowstone_grpc_proto::{
         convert_from::create_tx_with_meta,
         prelude::{
@@ -15,6 +16,7 @@ use {
         },
     },
 };
+
 pub struct GrpcIngester {
     url: String,
     token: String,
@@ -40,6 +42,124 @@ impl GrpcIngester {
     }
 }
 
+async fn spawn_op(
+    program: Pubkey,
+    txchan: UnboundedSender<Vec<BonsolInstruction>>,
+    stream_client: GeyserGrpcBuilder,
+) -> Result<()> {
+    let mut client = stream_client.connect().await?;
+    let mut txmap = HashMap::new();
+    txmap.insert(
+        program.to_string(),
+        SubscribeRequestFilterTransactions {
+            vote: Some(false),
+            failed: Some(false),
+            account_required: vec![program.to_string()],
+            ..Default::default()
+        },
+    );
+    let (_, mut stream) = client
+        .subscribe_with_request(Some(SubscribeRequest {
+            transactions: txmap,
+            ..Default::default()
+        }))
+        .await?;
+
+    while let Some(message) = stream.next().await {
+        match message {
+            Ok(msg) => {
+                if let Some(UpdateOneof::Transaction(txw)) = msg.update_oneof {
+                    if let Some(tx) = txw.transaction {
+                        if let Ok(soltxn) = create_tx_with_meta(tx) {
+                            let acc = soltxn.account_keys();
+                            let txndata = soltxn.get_transaction();
+                            let meta = soltxn.get_status_meta();
+                            //unwrap so we can consume
+                            if let VersionedMessage::V0(msg) = txndata.message {
+                                let bonsolixs = msg
+                                    .instructions
+                                    .into_iter()
+                                    .filter(|ix| {
+                                        acc.get(ix.program_id_index as usize) == Some(&program)
+                                    })
+                                    .map(|ix| BonsolInstruction {
+                                        cpi: false,
+                                        accounts: ix
+                                            .accounts
+                                            .into_iter()
+                                            .map(|idx| {
+                                                acc.get(idx as usize)
+                                                    .map(|a| *a)
+                                                    .unwrap_or_default()
+                                            })
+                                            .collect(),
+                                        data: ix.data,
+                                        last_known_block: txw.slot,
+                                    })
+                                    .collect::<Vec<BonsolInstruction>>();
+                                if bonsolixs.len() > 0 {
+                                    if let Err(e) = txchan.send(bonsolixs) {
+                                        eprintln!("Error sending to txn ingest channel: {e:?}")
+                                    }
+                                }
+
+                                if let Some(metadata) = meta {
+                                    if let Some(inner_ix) = metadata.inner_instructions {
+                                        let ixs = inner_ix
+                                            .into_iter()
+                                            .flat_map(|ix| {
+                                                ix.instructions
+                                                    .into_iter()
+                                                    .filter(|ix| {
+                                                        acc.get(
+                                                            ix.instruction.program_id_index
+                                                                as usize,
+                                                        ) == Some(&program)
+                                                    })
+                                                    .map(|ix| BonsolInstruction {
+                                                        cpi: true,
+                                                        accounts: ix
+                                                            .instruction
+                                                            .accounts
+                                                            .into_iter()
+                                                            .map(|a| {
+                                                                acc.get(a as usize)
+                                                                    .map(|a| *a)
+                                                                    .unwrap_or_default()
+                                                            })
+                                                            .collect(),
+                                                        data: ix.instruction.data,
+                                                        last_known_block: txw.slot,
+                                                    })
+                                                    .collect::<Vec<BonsolInstruction>>()
+                                            })
+                                            .collect::<Vec<BonsolInstruction>>();
+                                        if ixs.len() > 0 {
+                                            match txchan.send(ixs) {
+                                                Ok(_) => {}
+                                                Err(e) => {
+                                                    println!(
+                                                        "Error sending to txn ingest channel: {:?}",
+                                                        e
+                                                    );
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Err(_) => {
+                eprintln!("Error in stream");
+            }
+        }
+    }
+    Ok(())
+}
+
 impl Ingester for GrpcIngester {
     fn start(&mut self, program: Pubkey) -> Result<TxChannel> {
         let (txchan, rx) = tokio::sync::mpsc::unbounded_channel();
@@ -50,123 +170,7 @@ impl Ingester for GrpcIngester {
             ))
             .timeout(Duration::from_secs(self.timeout_secs.unwrap_or(10) as u64));
         self.op_handle = Some(tokio::spawn(async move {
-            let mut client = stream_client.connect().await?;
-            let mut txmap = HashMap::new();
-            txmap.insert(
-                program.to_string(),
-                SubscribeRequestFilterTransactions {
-                    vote: Some(false),
-                    failed: Some(false),
-                    account_required: vec![program.to_string()],
-                    ..Default::default()
-                },
-            );
-            let (_, mut stream) = client
-                .subscribe_with_request(Some(SubscribeRequest {
-                    transactions: txmap,
-                    ..Default::default()
-                }))
-                .await?;
-            while let Some(message) = stream.next().await {
-                match message {
-                    Ok(msg) => {
-                        if let Some(UpdateOneof::Transaction(txw)) = msg.update_oneof {
-                            if let Some(tx) = txw.transaction {
-                                if let Ok(soltxn) = create_tx_with_meta(tx) {
-                                    let acc = soltxn.account_keys();
-                                    let txndata = soltxn.get_transaction();
-                                    let meta = soltxn.get_status_meta();
-                                    //unwrap so we can consume
-                                    if let VersionedMessage::V0(msg) = txndata.message {
-                                        let bonsolixs = msg
-                                            .instructions
-                                            .into_iter()
-                                            .filter(|ix| {
-                                                acc.get(ix.program_id_index as usize)
-                                                    == Some(&program)
-                                            })
-                                            .map(|ix| BonsolInstruction {
-                                                cpi: false,
-                                                accounts: ix
-                                                    .accounts
-                                                    .into_iter()
-                                                    .map(|idx| {
-                                                        acc.get(idx as usize)
-                                                            .map(|a| *a)
-                                                            .unwrap_or_default()
-                                                    })
-                                                    .collect(),
-                                                data: ix.data,
-                                                last_known_block: txw.slot,
-                                            })
-                                            .collect::<Vec<BonsolInstruction>>();
-                                        if bonsolixs.len() > 0 {
-                                            match txchan.send(bonsolixs) {
-                                                Ok(_) => {}
-                                                Err(e) => {
-                                                    println!(
-                                                        "Error sending to txn ingest channel: {:?}",
-                                                        e
-                                                    );
-                                                }
-                                            }
-                                        }
-
-                                        if let Some(metadata) = meta {
-                                            if let Some(inner_ix) = metadata.inner_instructions {
-                                                let ixs = inner_ix
-                                                    .into_iter()
-                                                    .flat_map(|ix| {
-                                                        ix.instructions
-                                                            .into_iter()
-                                                            .filter(|ix| {
-                                                                acc.get(
-                                                                    ix.instruction.program_id_index
-                                                                        as usize,
-                                                                ) == Some(&program)
-                                                            })
-                                                            .map(|ix| BonsolInstruction {
-                                                                cpi: true,
-                                                                accounts: ix
-                                                                    .instruction
-                                                                    .accounts
-                                                                    .into_iter()
-                                                                    .map(|a| {
-                                                                        acc.get(a as usize)
-                                                                            .map(|a| *a)
-                                                                            .unwrap_or_default()
-                                                                    })
-                                                                    .collect(),
-                                                                data: ix.instruction.data,
-                                                                last_known_block: txw.slot,
-                                                            })
-                                                            .collect::<Vec<BonsolInstruction>>()
-                                                    })
-                                                    .collect::<Vec<BonsolInstruction>>();
-                                                if ixs.len() > 0 {
-                                                    match txchan.send(ixs) {
-                                                        Ok(_) => {}
-                                                        Err(e) => {
-                                                            println!(
-                                                                "Error sending to txn ingest channel: {:?}",
-                                                                e
-                                                            );
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    Err(_) => {
-                        println!("Error in stream");
-                    }
-                }
-            }
-            return Ok(());
+            spawn_op(program, txchan, stream_client).await
         }));
         Ok(rx)
     }
@@ -174,5 +178,24 @@ impl Ingester for GrpcIngester {
     fn stop(&mut self) -> Result<()> {
         self.op_handle.as_mut().map(|t| t.abort());
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod dragon_ingester_tests {
+    use solana_sdk::pubkey::Pubkey;
+
+    use super::{GrpcIngester, Ingester};
+
+    #[tokio::test]
+    async fn ingester_starts_and_stops() {
+        let mut ingester = GrpcIngester::new(
+            "http://localhost:8899".into(),
+            "test".into(),
+            Some(5),
+            Some(5),
+        );
+        assert!(ingester.start(Pubkey::new_unique()).is_ok());
+        assert!(ingester.stop().is_ok());
     }
 }

--- a/node/src/ingest/dragon.rs
+++ b/node/src/ingest/dragon.rs
@@ -1,5 +1,12 @@
 use std::{collections::HashMap, time::Duration};
 
+use {
+    anyhow::anyhow,
+    solana_sdk::{message::AccountKeys, transaction::VersionedTransaction},
+    solana_transaction_status::TransactionStatusMeta,
+    yellowstone_grpc_proto::geyser::SubscribeUpdate,
+};
+
 use crate::types::BonsolInstruction;
 
 use {
@@ -42,7 +49,28 @@ impl GrpcIngester {
     }
 }
 
-async fn spawn_op(
+impl Ingester for GrpcIngester {
+    fn start(&mut self, program: Pubkey) -> Result<TxChannel> {
+        let (txchan, rx) = tokio::sync::mpsc::unbounded_channel();
+        let stream_client = GeyserGrpcClient::build_from_shared(self.url.clone())?
+            .x_token(Some(self.token.clone()))?
+            .connect_timeout(Duration::from_secs(
+                self.connection_timeout_secs.unwrap_or(10) as u64,
+            ))
+            .timeout(Duration::from_secs(self.timeout_secs.unwrap_or(10) as u64));
+        self.op_handle = Some(tokio::spawn(async move {
+            ingest(program, txchan, stream_client).await
+        }));
+        Ok(rx)
+    }
+
+    fn stop(&mut self) -> Result<()> {
+        self.op_handle.as_mut().map(|t| t.abort());
+        Ok(())
+    }
+}
+
+async fn ingest(
     program: Pubkey,
     txchan: UnboundedSender<Vec<BonsolInstruction>>,
     stream_client: GeyserGrpcBuilder,
@@ -68,117 +96,115 @@ async fn spawn_op(
     while let Some(message) = stream.next().await {
         match message {
             Ok(msg) => {
-                if let Some(UpdateOneof::Transaction(txw)) = msg.update_oneof {
-                    if let Some(tx) = txw.transaction {
-                        if let Ok(soltxn) = create_tx_with_meta(tx) {
-                            let acc = soltxn.account_keys();
-                            let txndata = soltxn.get_transaction();
-                            let meta = soltxn.get_status_meta();
-                            //unwrap so we can consume
-                            if let VersionedMessage::V0(msg) = txndata.message {
-                                let bonsolixs = msg
-                                    .instructions
-                                    .into_iter()
-                                    .filter(|ix| {
-                                        acc.get(ix.program_id_index as usize) == Some(&program)
-                                    })
-                                    .map(|ix| BonsolInstruction {
-                                        cpi: false,
-                                        accounts: ix
-                                            .accounts
-                                            .into_iter()
-                                            .map(|idx| {
-                                                acc.get(idx as usize)
-                                                    .map(|a| *a)
-                                                    .unwrap_or_default()
-                                            })
-                                            .collect(),
-                                        data: ix.data,
-                                        last_known_block: txw.slot,
-                                    })
-                                    .collect::<Vec<BonsolInstruction>>();
-                                if bonsolixs.len() > 0 {
-                                    if let Err(e) = txchan.send(bonsolixs) {
-                                        eprintln!("Error sending to txn ingest channel: {e:?}")
-                                    }
-                                }
-
-                                if let Some(metadata) = meta {
-                                    if let Some(inner_ix) = metadata.inner_instructions {
-                                        let ixs = inner_ix
-                                            .into_iter()
-                                            .flat_map(|ix| {
-                                                ix.instructions
-                                                    .into_iter()
-                                                    .filter(|ix| {
-                                                        acc.get(
-                                                            ix.instruction.program_id_index
-                                                                as usize,
-                                                        ) == Some(&program)
-                                                    })
-                                                    .map(|ix| BonsolInstruction {
-                                                        cpi: true,
-                                                        accounts: ix
-                                                            .instruction
-                                                            .accounts
-                                                            .into_iter()
-                                                            .map(|a| {
-                                                                acc.get(a as usize)
-                                                                    .map(|a| *a)
-                                                                    .unwrap_or_default()
-                                                            })
-                                                            .collect(),
-                                                        data: ix.instruction.data,
-                                                        last_known_block: txw.slot,
-                                                    })
-                                                    .collect::<Vec<BonsolInstruction>>()
-                                            })
-                                            .collect::<Vec<BonsolInstruction>>();
-                                        if ixs.len() > 0 {
-                                            match txchan.send(ixs) {
-                                                Ok(_) => {}
-                                                Err(e) => {
-                                                    println!(
-                                                        "Error sending to txn ingest channel: {:?}",
-                                                        e
-                                                    );
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                if let Err(e) = handle_msg(msg, program, &txchan) {
+                    eprintln!("Error in stream: {e:?}")
                 }
             }
-            Err(_) => {
-                eprintln!("Error in stream");
-            }
+            Err(e) => eprintln!("Error in stream: {e:?}"),
         }
     }
     Ok(())
 }
 
-impl Ingester for GrpcIngester {
-    fn start(&mut self, program: Pubkey) -> Result<TxChannel> {
-        let (txchan, rx) = tokio::sync::mpsc::unbounded_channel();
-        let stream_client = GeyserGrpcClient::build_from_shared(self.url.clone())?
-            .x_token(Some(self.token.clone()))?
-            .connect_timeout(Duration::from_secs(
-                self.connection_timeout_secs.unwrap_or(10) as u64,
-            ))
-            .timeout(Duration::from_secs(self.timeout_secs.unwrap_or(10) as u64));
-        self.op_handle = Some(tokio::spawn(async move {
-            spawn_op(program, txchan, stream_client).await
-        }));
-        Ok(rx)
+fn handle_msg(
+    msg: SubscribeUpdate,
+    program: Pubkey,
+    txchan: &UnboundedSender<Vec<BonsolInstruction>>,
+) -> Result<()> {
+    if let Some(UpdateOneof::Transaction(txw)) = msg.update_oneof {
+        txw.transaction.map(|tx| -> Result<()> {
+            create_tx_with_meta(tx)
+                .map(|soltxn| {
+                    try_send_instructions(
+                        program,
+                        txw.slot,
+                        soltxn.account_keys(),
+                        soltxn.get_transaction(),
+                        soltxn.get_status_meta(),
+                        &txchan,
+                    )
+                })
+                .map_err(|e| anyhow!("error while sending instructions: {e}"))?
+        });
     }
+    Ok(())
+}
 
-    fn stop(&mut self) -> Result<()> {
-        self.op_handle.as_mut().map(|t| t.abort());
-        Ok(())
+fn try_send_instructions(
+    program: Pubkey,
+    last_known_block: u64,
+    acc: AccountKeys,
+    txndata: VersionedTransaction,
+    meta: Option<TransactionStatusMeta>,
+    txchan: &UnboundedSender<Vec<BonsolInstruction>>,
+) -> Result<()> {
+    if let VersionedMessage::V0(msg) = txndata.message {
+        let bonsolixs = msg
+            .instructions
+            .into_iter()
+            .filter_map(|ix| {
+                if acc
+                    .get(ix.program_id_index as usize)
+                    .is_some_and(|p| p == &program)
+                {
+                    return Some(BonsolInstruction::new(
+                        false,
+                        ix.accounts
+                            .into_iter()
+                            .filter_map(|idx| acc.get(idx as usize).copied())
+                            .collect(),
+                        ix.data,
+                        last_known_block,
+                    ));
+                }
+                None
+            })
+            .collect::<Vec<BonsolInstruction>>();
+        if !bonsolixs.is_empty() {
+            txchan.send(bonsolixs).map_err(|e| {
+                anyhow!(
+                    "failed to send instructions to txn ingest channel: {:?}",
+                    e.0
+                )
+            })?
+        }
+        if let Some(metadata) = meta {
+            if let Some(inner_ix) = metadata.inner_instructions {
+                let ixs = inner_ix
+                    .into_iter()
+                    .flat_map(|ix| {
+                        ix.instructions.into_iter().filter_map(|ix| {
+                            if acc
+                                .get(ix.instruction.program_id_index as usize)
+                                .is_some_and(|p| p == &program)
+                            {
+                                return Some(BonsolInstruction::new(
+                                    true,
+                                    ix.instruction
+                                        .accounts
+                                        .into_iter()
+                                        .filter_map(|a| acc.get(a as usize).copied())
+                                        .collect(),
+                                    ix.instruction.data,
+                                    last_known_block,
+                                ));
+                            }
+                            None
+                        })
+                    })
+                    .collect::<Vec<BonsolInstruction>>();
+                if !ixs.is_empty() {
+                    txchan.send(ixs).map_err(|e| {
+                        anyhow!(
+                            "failed to send instructions to txn ingest channel: {:?}",
+                            e.0
+                        )
+                    })?
+                }
+            }
+        }
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -8,6 +8,17 @@ pub struct BonsolInstruction {
     pub last_known_block: u64,
 }
 
+impl BonsolInstruction {
+    pub fn new(cpi: bool, accounts: Vec<Pubkey>, data: Vec<u8>, last_known_block: u64) -> Self {
+        Self {
+            cpi,
+            accounts,
+            data,
+            last_known_block,
+        }
+    }
+}
+
 pub enum CallbackStatus {
     Completed,
     Failure,

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -1,7 +1,10 @@
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::{instruction::CompiledInstruction, message::AccountKeys, pubkey::Pubkey};
+use solana_transaction_status::InnerInstruction;
 
 #[derive(Debug)]
 pub struct BonsolInstruction {
+    /// Whether we picked up an instruction that was an inner instruction
+    /// found in the metadata.
     pub cpi: bool,
     pub accounts: Vec<Pubkey>,
     pub data: Vec<u8>,
@@ -17,6 +20,74 @@ impl BonsolInstruction {
             last_known_block,
         }
     }
+    fn inner(accounts: Vec<Pubkey>, data: Vec<u8>, last_known_block: u64) -> Self {
+        Self::new(true, accounts, data, last_known_block)
+    }
+    fn outer(accounts: Vec<Pubkey>, data: Vec<u8>, last_known_block: u64) -> Self {
+        Self::new(false, accounts, data, last_known_block)
+    }
+}
+
+/// Conversion trait for Inner and Outer instructions to become Bonsol instructions.
+/// This does not use From and Into because it requires context other than just
+/// the instructions themselves.
+pub trait IntoBonsolInstruction {
+    /// Convert an instruction into a [`BonsolInstruction`].
+    fn into_bonsol_ix(self, acc: &AccountKeys, last_known_block: u64) -> BonsolInstruction;
+    /// Get the index of the `Pubkey` that represents the program in the `AccountKeys` map.
+    fn program_id_index(&self) -> u8;
+}
+
+impl IntoBonsolInstruction for InnerInstruction {
+    fn into_bonsol_ix(self, acc: &AccountKeys, last_known_block: u64) -> BonsolInstruction {
+        BonsolInstruction::inner(
+            self.instruction
+                .accounts
+                .into_iter()
+                .filter_map(|idx| acc.get(idx as usize).copied())
+                .collect(),
+            self.instruction.data,
+            last_known_block,
+        )
+    }
+    fn program_id_index(&self) -> u8 {
+        self.instruction.program_id_index
+    }
+}
+
+impl IntoBonsolInstruction for CompiledInstruction {
+    fn into_bonsol_ix(self, acc: &AccountKeys, last_known_block: u64) -> BonsolInstruction {
+        BonsolInstruction::outer(
+            self.accounts
+                .into_iter()
+                .filter_map(|idx| acc.get(idx as usize).copied())
+                .collect(),
+            self.data,
+            last_known_block,
+        )
+    }
+    fn program_id_index(&self) -> u8 {
+        self.program_id_index
+    }
+}
+
+/// Filter instructions that can be converted to `BonsolInstruction`s given
+/// a closure which returns a boolean representing some condition that must be met
+/// for an instruction to be converted to `Some(BonsolInstruction)`.
+pub fn filter_bonsol_instructions<'a, I>(
+    ixs: Vec<I>,
+    acc: &'a AccountKeys,
+    program: &'a Pubkey,
+    last_known_block: u64,
+    program_filter: impl Fn(&AccountKeys, &Pubkey, usize) -> bool + 'a,
+) -> impl Iterator<Item = BonsolInstruction> + 'a
+where
+    I: IntoBonsolInstruction + 'a,
+{
+    ixs.into_iter().filter_map(move |ix| {
+        program_filter(acc, program, ix.program_id_index() as usize)
+            .then(|| ix.into_bonsol_ix(acc, last_known_block))
+    })
 }
 
 pub enum CallbackStatus {

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -1,5 +1,7 @@
-use solana_sdk::{instruction::CompiledInstruction, message::AccountKeys, pubkey::Pubkey};
-use solana_transaction_status::InnerInstruction;
+use {
+    solana_sdk::{instruction::CompiledInstruction, message::AccountKeys, pubkey::Pubkey},
+    solana_transaction_status::InnerInstruction,
+};
 
 #[derive(Debug)]
 pub struct BonsolInstruction {


### PR DESCRIPTION
Closes #21 

Abstracts the logic of the dragon ingester module into more digestible chunks, and adds unit tests to prevent regressions.