### PR TITLE
chore: Use workspace version for workspace crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "callback-example"
-version = "0.0.1"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bonsol-interface",
@@ -3494,7 +3494,7 @@ checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "iop"
-version = "0.1.0"
+version = "0.2.1"
 
 [[package]]
 name = "ipnet"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "bonsol-cli"
-version = "0.2.1"
+version.workspace = true
 edition = "2021"
-publish = false     # Exclude local crates from licensing checks
+publish = false          # Exclude local crates from licensing checks
 
 [[bin]]
 name = "bonsol"

--- a/flake.nix
+++ b/flake.nix
@@ -109,7 +109,7 @@
 
           individualCrateArgs = commonArgs // {
             inherit cargoArtifacts;
-            inherit (craneLib.crateNameFromCargoToml { inherit src; }) version;
+            inherit (craneLib.crateNameFromCargoToml { inherit (workspace) src; }) version;
             doCheck = false;
           };
 
@@ -150,7 +150,7 @@
               };
             in
             craneLib.buildPackage (individualCrateArgs // {
-              inherit (manifest) version pname;
+              inherit (manifest) pname;
               cargoExtraArgs = "--locked --bin ${name}";
               src = fileSetForCrate crate deps;
             });

--- a/iop/Cargo.toml
+++ b/iop/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iop"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
-publish = false   # Exclude local crates from licensing checks
+publish = false          # Exclude local crates from licensing checks
 
 
 [dependencies]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "bonsol-node"
-version = "0.2.1"
+version.workspace = true
 edition = "2021"
-publish = false      # Exclude local crates from licensing checks
+publish = false          # Exclude local crates from licensing checks
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/onchain/bonsol/Cargo.toml
+++ b/onchain/bonsol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bonsol"
-version = "0.2.1"
+version.workspace = true
 description = "Solana channel to bonsai"
 authors = ["anagram build team"]
 repository = "https://github.com/anagrambuild/bonsol"

--- a/onchain/example-callback-program/Cargo.toml
+++ b/onchain/example-callback-program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "callback-example"
-version = "0.0.1"
+version.workspace = true
 description = "example raw solana program to show how to use the callback feature of bonsol"
 authors = ["anagram build team"]
 repository = "https://github.com/anagrambuild/bonsol"

--- a/onchain/interface/Cargo.toml
+++ b/onchain/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bonsol-interface"
-version = "0.2.1"
+version.workspace = true
 edition = "2021"
 publish = false           # Exclude local crates from licensing checks
 

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "bonsol-prover"
-version = "0.2.1"
+version.workspace = true
 edition = "2021"
-publish = false        # Exclude local crates from licensing checks
+publish = false          # Exclude local crates from licensing checks
 
 [dependencies]
 anyhow = "1.0.86"

--- a/schemas-rust/Cargo.toml
+++ b/schemas-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bonsol-schema"
-version = "0.2.1"
+version.workspace = true
 description = "Bonsol types, schema definitions"
 authors = ["anagram build team"]
 repository = "https://github.com/anagrambuild/bonsol"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "bonsol-sdk"
-version = "0.2.1"
+version.workspace = true
 edition = "2021"
-publish = false     # Exclude local crates from licensing checks
+publish = false          # Exclude local crates from licensing checks
 
 [dependencies]
 anyhow = "1.0.86"


### PR DESCRIPTION
Closes #58 

Uses the version specified in the workspace package as the version for all packages under the workspace members field. Also fixes a small logical issue for inheritance of the workspace version for crates in `flake.nix`.