### PR TITLE
fix: Fix byte calculation in `download_public_input`, update validator and run-node scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode
 .DS_Store
+.idea
 relaykp.json
 target
 result*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,6 +846,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1308,7 @@ dependencies = [
  "bonsol-schema",
  "bytes",
  "futures-util",
+ "mockito",
  "reqwest",
  "risc0-binfmt",
  "risc0-zkvm",
@@ -1807,6 +1818,16 @@ name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "combine"
@@ -3997,6 +4018,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockito"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b34bd91b9e5c5b06338d392463e1318d683cf82ec3d3af4014609be6e2108d"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "log",
+ "rand 0.8.5",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
 name = "modular-bitfield"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6053,6 +6098,12 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "siphasher"

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -25,3 +25,6 @@ solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-sdk = { workspace = true }
 tokio = "1.36.0"
+
+[dev-dependencies]
+mockito = "1.5.0"

--- a/prover/src/input_resolver.rs
+++ b/prover/src/input_resolver.rs
@@ -377,9 +377,9 @@ async fn download_private_input(
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::sync::Arc;
     use mockito::Mock;
     use reqwest::{Client, Url};
+    use std::sync::Arc;
 
     // Modified to return the server along with the mock and URL
     pub async fn get_server(url_path: &str, response: &[u8]) -> (Mock, Url, mockito::ServerGuard) {
@@ -402,7 +402,7 @@ mod test {
         // 1 MB max size
         let max_size_mb = 1;
         // 10 KB response
-        let input_data = vec![1u8; 1024*10];
+        let input_data = vec![1u8; 1024 * 10];
 
         let (mock, url, _server) = get_server("/download", &input_data).await;
         let client = Arc::new(Client::new());
@@ -414,13 +414,16 @@ mod test {
             max_size_mb,
             ProgramInputType::Public,
         )
-            .await;
+        .await;
 
         assert!(valid_result.is_ok());
         let resolved_input = valid_result.unwrap();
         assert_eq!(resolved_input.index, 1);
         assert_eq!(resolved_input.data, input_data);
-        assert!(matches!(resolved_input.input_type, ProgramInputType::Public));
+        assert!(matches!(
+            resolved_input.input_type,
+            ProgramInputType::Public
+        ));
 
         mock.assert();
     }
@@ -430,7 +433,7 @@ mod test {
         // 1 MB max size
         let max_size_mb = 1;
         // 2 MB response
-        let input_data = vec![1u8; 1024*1024*2];
+        let input_data = vec![1u8; 1024 * 1024 * 2];
 
         let (mock, url, _server) = get_server("/download", &input_data).await;
         let client = Arc::new(Client::new());
@@ -442,13 +445,11 @@ mod test {
             max_size_mb,
             ProgramInputType::Public,
         )
-            .await;
+        .await;
 
         assert!(valid_result.is_err());
         assert_eq!(valid_result.unwrap_err().to_string(), "Max size exceeded");
 
         mock.assert();
     }
-
 }
-

--- a/prover/src/input_resolver.rs
+++ b/prover/src/input_resolver.rs
@@ -337,11 +337,11 @@ async fn dowload_public_input(
     client: Arc<reqwest::Client>,
     index: u8,
     url: Url,
-    max_size: usize,
+    max_size_mb: usize,
     input_type: ProgramInputType,
 ) -> Result<ResolvedInput> {
     let resp = client.get(url).send().await?.error_for_status()?;
-    let byte = get_body_max_size(resp.bytes_stream(), max_size).await?;
+    let byte = get_body_max_size(resp.bytes_stream(), max_size_mb * 1024 * 1024).await?;
     Ok(ResolvedInput {
         index,
         data: byte.to_vec(),
@@ -353,7 +353,7 @@ async fn download_private_input(
     client: Arc<reqwest::Client>,
     index: u8,
     url: Url,
-    max_size: usize,
+    max_size_mb: usize,
     body: String,
     claim_authorization: String,
 ) -> Result<ResolvedInput> {
@@ -366,7 +366,7 @@ async fn download_private_input(
         .send()
         .await?
         .error_for_status()?;
-    let byte = get_body_max_size(resp.bytes_stream(), max_size).await?;
+    let byte = get_body_max_size(resp.bytes_stream(), max_size_mb * 1024 * 1024).await?;
     Ok(ResolvedInput {
         index,
         data: byte.to_vec(),

--- a/run-node.sh
+++ b/run-node.sh
@@ -1,19 +1,58 @@
-#!/bin/zsh
+#!/usr/bin/env bash
+
+if [ -x "$(command -v zsh)" ]; then
+    exec zsh "$0" "$@"
+fi
+
 set -e
+
 NKP=node_keypair.json
-if [ -f $RKP ]; then
+USE_CUDA=false
+
+while getopts "F:" opt; do
+  case $opt in
+    F)
+      if [ "$OPTARG" = "cuda" ]; then
+        USE_CUDA=true
+      else
+        echo "Error: Unknown feature flag: $OPTARG"
+        exit 1
+      fi
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -f $NKP ]; then
     echo "Bonsol node keypair exists"
 else
     solana-keygen new --outfile $NKP
 fi
+
 solana -u http://localhost:8899 airdrop 1 --keypair node_keypair.json
 solana -u http://localhost:8899 airdrop 1
 ulimit -s unlimited
+
 (cd node;
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    cargo run --release -p bonsol-node -- -f ./Node.toml
+    if [ "$USE_CUDA" = true ]; then
+        cargo run --release -p bonsol-node --features cuda -- -f ./Node.toml
+    else
+        cargo run --release -p bonsol-node -- -f ./Node.toml
+    fi
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "NOTE: MAC Arm cpus will not be able to run the stark to snark prover, this is a known issue"
-    cargo run --release -p bonsol-node --features metal -- -f ./Node.toml
+    if [ "$USE_CUDA" = true ]; then
+        echo "Error: CUDA is not supported on macOS"
+        exit 1
+    else
+        echo "NOTE: MAC Arm CPUs will not be able to run the stark to snark prover, this is a known issue"
+        cargo run --release -p bonsol-node --features metal -- -f ./Node.toml
+    fi
+else
+    echo "Unsupported operating system"
+    exit 1
 fi
 )

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -10,7 +10,7 @@ use num_traits::FromPrimitive;
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_rpc_client_api::config::RpcSendTransactionConfig;
 use solana_sdk::account::Account;
-use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::commitment_config::{CommitmentConfig, CommitmentLevel};
 use solana_sdk::compute_budget::ComputeBudgetInstruction;
 use solana_sdk::instruction::Instruction;
 use solana_sdk::message::{v0, VersionedMessage};
@@ -217,6 +217,7 @@ impl BonsolClient {
                     &tx,
                     RpcSendTransactionConfig {
                         skip_preflight,
+                        preflight_commitment: Some(CommitmentLevel::Confirmed),
                         max_retries: Some(0),
                         ..Default::default()
                     },

--- a/validator.sh
+++ b/validator.sh
@@ -1,11 +1,60 @@
-#!/bin/zsh
-set -x
+#!/usr/bin/env bash
+
+# zsh if available, else keep bash
+if [ -x "$(command -v zsh)" ]; then
+    exec zsh "$0" "$@"
+fi
+
+set -e
 export COPYFILE_DISABLE=1
+
+print_usage() {
+    echo "Usage: $0 [--bpf-program <address> <path>]... [-r]"
+    echo "  --bpf-program: Add a BPF program with its address and path"
+    echo "  -r: Run with '--reset' option (optional)"
+    echo "sample usage: ./validator.sh -r --bpf-program CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d ../../mainnet_bpf_programs/core.so"
+}
+
+extra_programs=()
+reset_option=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --bpf-program)
+            if [[ $# -lt 3 ]]; then
+                echo "Error: --bpf-program requires two arguments: <address> <path>"
+                print_usage
+                exit 1
+            fi
+            extra_programs+=("--bpf-program" "$2" "$3")
+            shift 3
+            ;;
+        -r)
+            reset_option="-r"
+            shift
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            print_usage
+            exit 1
+            ;;
+    esac
+done
+
+set -x
+
 cargo --version
+
+
 cargo build-sbf && solana-test-validator \
-   --limit-ledger-size 0 \
-   --bind-address 0.0.0.0 \
-   --rpc-pubsub-enable-block-subscription \
-    --bpf-program BoNsHRcyLLNdtnoDf8hiCNZpyehMC4FDMxs6NTxFi3ew target/deploy/bonsol.so  \
+    --limit-ledger-size 0 \
+    --bind-address 0.0.0.0 \
+    --rpc-pubsub-enable-block-subscription \
+    --bpf-program BoNsHRcyLLNdtnoDf8hiCNZpyehMC4FDMxs6NTxFi3ew target/deploy/bonsol.so \
     --bpf-program exay1T7QqsJPNcwzMiWubR6vZnqrgM16jZRraHgqBGG target/deploy/callback_example.so \
-    -r
+    "${extra_programs[@]}" \
+    $reset_option


### PR DESCRIPTION
### Changes
* Added a calculation fix for `max_size`, since it's passed in MB. changed the param name to `max_size_mb` and added a 1024*1024 in the call so the right byte count is passed
* Quality of life improvements for 
 * `validator.sh`: Allow passing in additional programs using --bpf-program, since users might want to pass other programs (such as metaplex core). Made -r optional since we don't always want to wipe the local validator ledger
 * `run-node.sh`: Added -F cuda as optional