### PR TITLE
merge error fix

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -217,7 +217,6 @@ impl BonsolClient {
                     &tx,
                     RpcSendTransactionConfig {
                         skip_preflight,
-                        preflight_commitment: Some(CommitmentLevel::Confirmed),
                         max_retries: Some(0),
                         preflight_commitment: Some(self.rpc_client.commitment().commitment),
                         ..Default::default()


### PR DESCRIPTION
seems like two different commits added `preflight_commitment`, so its causing an error when building the bonsol client.
Just removed one of them