### PR TITLE
chore: Automatically update binary cache

### DIFF
--- a/.github/workflows/update-cachix.yml
+++ b/.github/workflows/update-cachix.yml
@@ -1,0 +1,42 @@
+# Updates the bonsol nix binary cache hosted via cachix:
+#
+# substituter: https://bonsol.cachix.org
+# public-key: bonsol.cachix.org-1:yz7vi1rCPW1BpqoszdJvf08HZxQ/5gPTPxft4NnT74A=
+
+name: Update Cachix
+on:
+  push:
+    branches:
+      - main
+concurrency:
+  group: main-build-cache
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  update-cachix:
+    name: Update Cachix
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: "write"
+      contents: "read"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            extra-substituters = https://bonsol.cachix.org
+            extra-trusted-public-keys = bonsol.cachix.org-1:yz7vi1rCPW1BpqoszdJvf08HZxQ/5gPTPxft4NnT74A=
+
+      - name: Install and configure Cachix
+        uses: cachix/cachix-action@v15
+        with:
+          name: bonsol
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'          
+
+        run: nix flake check
+        run: nix develop


### PR DESCRIPTION
Closes #50 

Ensures the developer cache is always up-to-date with main.