### PR TITLE
feat: versioned execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ images/**/manifest.json
 stark
 MyLogFile.log
 *_generated.rs
+.pnpm-store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,6 +1191,7 @@ dependencies = [
  "anyhow",
  "atty",
  "bincode",
+ "bonsol-interface",
  "bonsol-prover",
  "bonsol-sdk",
  "byte-unit",
@@ -1222,6 +1223,7 @@ version = "0.2.1"
 dependencies = [
  "anchor-lang 0.30.1",
  "arrayref",
+ "base64 0.21.7",
  "bonsol-schema",
  "bytemuck",
  "flatbuffers",
@@ -1338,6 +1340,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bonsol-interface",
+ "bonsol-schema",
  "bytes",
  "flatbuffers",
  "futures-util",
@@ -1359,6 +1362,7 @@ version = "0.2.1"
 dependencies = [
  "anyhow",
  "bonsol-cli",
+ "bonsol-interface",
  "bonsol-sdk",
  "rand 0.8.5",
  "solana-rpc-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,11 @@ risc0-circuit-recursion = { git = "https://github.com/anagrambuild/risc0", branc
 risc0-sys = { git = "https:m//github.com/anagrambuild/risc0", branch = "v1.0.1-bonsai-fix" }
 tokio-test = "0.4.3"
 
+bonsol-interface = { path = "./onchain/interface" }
+bonsol-schema = { path = "./schemas-rust" }
+bonsol-cli = { path = "./cli" }
+bonsol-sdk = { path = "./sdk" }
+
 [workspace.lints.clippy]
 clone_on_ref_ptr = "deny"
 missing_const_for_fn = "deny"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,3 +44,5 @@ solana-rpc-client = { workspace = true }
 solana-sdk = { workspace = true }
 tera = "1.17.1"
 tokio = { version = "1.38.0", features = ["full"] }
+
+bonsol-interface.workspace = true

--- a/cli/src/execute.rs
+++ b/cli/src/execute.rs
@@ -1,6 +1,5 @@
 use crate::common::*;
 use anyhow::Result;
-use bonsol_interface::prover_version::ProverVersion;
 use bonsol_prover::input_resolver::{DefaultInputResolver, InputResolver, ProgramInput};
 use bonsol_sdk::instructions::{ExecutionConfig, InputRef};
 use bonsol_sdk::{BonsolClient, ExecutionAccountStatus, InputType};
@@ -172,7 +171,6 @@ pub async fn execute(
     println!("Execution expiry {}", expiry);
     println!("current block {}", current_block);
     indicator.set_message("Building transaction");
-    let prover_version = ProverVersion::default();
     let ixs = sdk
         .execute_v1(
             &signer,
@@ -191,7 +189,7 @@ pub async fn execute(
             expiry,
             execution_config,
             callback_config.map(|c| c.into()),
-            Some(prover_version),
+            None, // A future cli change can implement prover version selection
         )
         .await?;
     indicator.finish_with_message("Sending transaction");

--- a/cli/src/execute.rs
+++ b/cli/src/execute.rs
@@ -1,5 +1,6 @@
 use crate::common::*;
 use anyhow::Result;
+use bonsol_interface::prover_version::ProverVersion;
 use bonsol_prover::input_resolver::{DefaultInputResolver, InputResolver, ProgramInput};
 use bonsol_sdk::instructions::{ExecutionConfig, InputRef};
 use bonsol_sdk::{BonsolClient, ExecutionAccountStatus, InputType};
@@ -171,7 +172,7 @@ pub async fn execute(
     println!("Execution expiry {}", expiry);
     println!("current block {}", current_block);
     indicator.set_message("Building transaction");
-
+    let prover_version = ProverVersion::default();
     let ixs = sdk
         .execute_v1(
             &signer,
@@ -190,6 +191,7 @@ pub async fn execute(
             expiry,
             execution_config,
             callback_config.map(|c| c.into()),
+            Some(prover_version),
         )
         .await?;
     indicator.finish_with_message("Sending transaction");

--- a/docs/docs/contributing/contributing.mdx
+++ b/docs/docs/contributing/contributing.mdx
@@ -70,7 +70,7 @@ cargo run -p bonsol-cli build -z images/simple
 ```
 5. Use the bonsol cli to deploy a zkprogram (here is a example already uploaded for you)
 ```bash
-cargo run -p bonsol-cli deploy -m images/simple/manifest.json -t url --url https://bonsol-public-images.s3.amazonaws.com/simple-68f4b0c5f9ce034aa60ceb264a18d6c410a3af68fafd931bcfd9ebe7c1e42960
+cargo run -p bonsol-cli deploy -m images/simple/manifest.json -t url --url https://bonsol-public-images.s3.us-east-1.amazonaws.com/simple-058530737d1b86e43ed2529f114b85195c27290fcf0844623b1ccb14934e8218
 ```
 6. Use the bonsol cli to execute a zkprogram
 ```bash

--- a/docs/docs/contributing/contributing.mdx
+++ b/docs/docs/contributing/contributing.mdx
@@ -70,7 +70,7 @@ cargo run -p bonsol-cli build -z images/simple
 ```
 5. Use the bonsol cli to deploy a zkprogram (here is a example already uploaded for you)
 ```bash
-cargo run -p bonsol-cli deploy -m images/simple/manifest.json -t url --url https://bonsol-public-images.s3.us-east-1.amazonaws.com/simple-058530737d1b86e43ed2529f114b85195c27290fcf0844623b1ccb14934e8218
+cargo run -p bonsol-cli deploy -m images/simple/manifest.json -t url --url https://bonsol-public-images.s3.us-east-1.amazonaws.com/simple-68f4b0c5f9ce034aa60ceb264a18d6c410a3af68fafd931bcfd9ebe7c1e42960
 ```
 6. Use the bonsol cli to execute a zkprogram
 ```bash

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -21,7 +21,6 @@ ark-relations = { version = "0.4.0" }
 ark-serialize = "0.4.0"
 ark-std = { version = "0.4.0" }
 async-trait = "0.1.80"
-bonsol-interface = { path = "../onchain/interface" }
 bonsol-prover = { path = "../prover" }
 bytemuck = "1.15.0"
 byteorder = "1.5.0"
@@ -80,6 +79,8 @@ tracing-subscriber = { version = "0.3.18", features = [
 ] }
 yellowstone-grpc-client = { workspace = true }
 yellowstone-grpc-proto = { workspace = true }
+
+bonsol-interface.workspace = true
 
 [dev-dependencies]
 expect-test = "1.5.0"

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -19,7 +19,7 @@ use {
     rlimit::Resource,
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_sdk::{pubkey::Pubkey, signature::read_keypair_file, signer::Signer},
-    std::{path::Path, str::FromStr, sync::Arc},
+    std::{str::FromStr, sync::Arc},
     thiserror::Error,
     tokio::{select, signal},
     tracing::{error, info},

--- a/node/src/observe/mod.rs
+++ b/node/src/observe/mod.rs
@@ -26,6 +26,7 @@ pub enum MetricEvents {
     ProofSegments,
     BonsolStartup,
     SignaturesInFlight,
+    IncompatibleProverVersion,
 }
 
 macro_rules! emit_event {

--- a/node/src/prover/verify_prover_version.rs
+++ b/node/src/prover/verify_prover_version.rs
@@ -1,0 +1,54 @@
+use {anyhow::Result, tracing::info};
+
+use risc0_zkvm::{sha::Digestible, Groth16ReceiptVerifierParameters};
+
+use bonsol_interface::prover_version::ProverVersion;
+
+pub fn verify_prover_version(required: ProverVersion) -> Result<()> {
+    let actual_digest = Groth16ReceiptVerifierParameters::default().digest();
+    let prover_digest = actual_digest.to_string();
+
+    match required {
+        ProverVersion::V1_0_1 {
+            verifier_digest, ..
+        } => {
+            if verifier_digest != prover_digest {
+                return Err(anyhow::anyhow!(
+                    "Prover version mismatch, expected: {}, got: {}",
+                    verifier_digest,
+                    prover_digest
+                ));
+            }
+            info!("Risc0 Prover with digest {}", verifier_digest);
+        }
+        _ => {
+            return Err(anyhow::anyhow!("Unsupported prover version"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, bonsol_interface::prover_version::VERSION_V1_0_1};
+
+    #[test]
+    fn test_verify_prover_version() {
+        assert!(verify_prover_version(VERSION_V1_0_1).is_ok());
+    }
+
+    #[test]
+    fn test_verify_prover_version_fail() {
+        let version_malade = ProverVersion::V1_0_1 {
+            verifier_digest: "malade",
+        };
+        let result = verify_prover_version(version_malade);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_verify_default_prover_version_is_supported() {
+        let result = verify_prover_version(ProverVersion::default());
+        assert!(result.is_ok());
+    }
+}

--- a/onchain/example-program-on-bonsol/src/lib.rs
+++ b/onchain/example-program-on-bonsol/src/lib.rs
@@ -88,6 +88,7 @@ fn main<'a>(
                         AccountMeta::new_readonly(EA3, false),
                     ],
                 }),
+                None,
             )
             .map_err(|_| ProgramError::InvalidInstructionData)?;
             invoke_signed(&ix, accounts, &[&[execution_id.as_bytes(), &[bump]]])?;

--- a/onchain/interface/Cargo.toml
+++ b/onchain/interface/Cargo.toml
@@ -12,7 +12,7 @@ idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
 arrayref = "0.3.6"
-bonsol-schema = { path = "../../schemas-rust", version = "0.2.1" }
+base64 = "0.21.2"
 bytemuck = { version = "1.15.0", features = ["derive"] }
 flatbuffers = { workspace = true }
 hex = "0.4.3"
@@ -22,6 +22,8 @@ sha3 = "0.10"
 solana-program = { workspace = true, optional = true }
 solana-sdk = { workspace = true, optional = true }
 thiserror = { workspace = true }
+
+bonsol-schema.workspace = true
 
 [dependencies.anchor-lang]
 optional = true

--- a/onchain/interface/src/instructions.rs
+++ b/onchain/interface/src/instructions.rs
@@ -1,7 +1,7 @@
 use bonsol_schema::{
     Account, ChannelInstruction, ChannelInstructionArgs, ChannelInstructionIxType, DeployV1,
     DeployV1Args, ExecutionRequestV1, ExecutionRequestV1Args, InputBuilder, InputT, InputType,
-    ProgramInputType,
+    ProgramInputType, ProverVersion,
 };
 use flatbuffers::{FlatBufferBuilder, WIPOffset};
 
@@ -220,6 +220,7 @@ pub fn execute_v1<'a>(
     expiration: u64,
     config: ExecutionConfig<'a>,
     callback: Option<CallbackConfig>,
+    prover_version: Option<ProverVersion>,
 ) -> Result<Instruction, ClientError> {
     let (execution_account, _) = execution_address(requester, execution_id.as_bytes());
     let (deployment_account, _) = deployment_address(image_id);
@@ -235,6 +236,7 @@ pub fn execute_v1<'a>(
         expiration,
         config,
         callback,
+        prover_version,
     )
 }
 /// Executes a bonsol program with the provided accounts
@@ -252,6 +254,7 @@ pub fn execute_v1_with_accounts<'a>(
     expiration: u64,
     config: ExecutionConfig,
     callback: Option<CallbackConfig>,
+    prover_version: Option<ProverVersion>,
 ) -> Result<Instruction, ClientError> {
     config.validate()?;
     let mut fbb = FlatBufferBuilder::new();
@@ -318,6 +321,10 @@ pub fn execute_v1_with_accounts<'a>(
     } else {
         None
     };
+
+    let prover_version = prover_version.or(Some(ProverVersion::default()));
+    let prover_version = prover_version.unwrap();
+
     let fbb_execute = ExecutionRequestV1::create(
         &mut fbb,
         &ExecutionRequestV1Args {
@@ -332,6 +339,7 @@ pub fn execute_v1_with_accounts<'a>(
             max_block_height: expiration,
             input_digest,
             callback_extra_accounts: extra_accounts,
+            prover_version,
         },
     );
     fbb.finish(fbb_execute, None);

--- a/onchain/interface/src/instructions.rs
+++ b/onchain/interface/src/instructions.rs
@@ -322,8 +322,9 @@ pub fn execute_v1_with_accounts<'a>(
         None
     };
 
+    // typically cli will pass None for the optional prover_version indicating bonsol should handle
+    // the default case here
     let prover_version = prover_version.unwrap_or(ProverVersion::default());
-
     let fbb_execute = ExecutionRequestV1::create(
         &mut fbb,
         &ExecutionRequestV1Args {
@@ -338,7 +339,7 @@ pub fn execute_v1_with_accounts<'a>(
             max_block_height: expiration,
             input_digest,
             callback_extra_accounts: extra_accounts,
-            prover_version,
+            prover_version: prover_version,
         },
     );
     fbb.finish(fbb_execute, None);

--- a/onchain/interface/src/instructions.rs
+++ b/onchain/interface/src/instructions.rs
@@ -322,8 +322,7 @@ pub fn execute_v1_with_accounts<'a>(
         None
     };
 
-    let prover_version = prover_version.or(Some(ProverVersion::default()));
-    let prover_version = prover_version.unwrap();
+    let prover_version = prover_version.unwrap_or(ProverVersion::default());
 
     let fbb_execute = ExecutionRequestV1::create(
         &mut fbb,

--- a/onchain/interface/src/lib.rs
+++ b/onchain/interface/src/lib.rs
@@ -5,6 +5,7 @@ pub mod callback;
 pub mod claim_state;
 pub mod error;
 pub mod instructions;
+pub mod prover_version;
 pub mod util;
 
 pub use bonsol_schema;

--- a/onchain/interface/src/prover_version.rs
+++ b/onchain/interface/src/prover_version.rs
@@ -30,7 +30,7 @@ impl TryFrom<FBSProverVersion> for ProverVersion {
 
     fn try_from(prover_version: FBSProverVersion) -> Result<Self, Self::Error> {
         match prover_version {
-            FBSProverVersion::V1_0_1 => Ok(VERSION_V1_0_1),
+            FBSProverVersion::V1_0_1 | FBSProverVersion::DEFAULT => Ok(VERSION_V1_0_1),
             _ => Err(ProverVersionError::UnsupportedVersion),
         }
     }
@@ -104,5 +104,13 @@ mod tests {
             fbs_version.unwrap_err(),
             ProverVersionError::UnsupportedVersion
         );
+    }
+
+    #[test]
+    fn test_default_into_current_version() {
+        let default_version = FBSProverVersion::DEFAULT;
+        let version = ProverVersion::try_from(default_version);
+        assert!(version.is_ok());
+        assert_eq!(version.unwrap(), VERSION_V1_0_1);
     }
 }

--- a/onchain/interface/src/prover_version.rs
+++ b/onchain/interface/src/prover_version.rs
@@ -1,0 +1,108 @@
+use std::convert::{TryFrom, TryInto};
+
+use bonsol_schema::ProverVersion as FBSProverVersion;
+
+pub const DIGEST_V1_0_1_BYTES: &'static str =
+    "310fe598e8e3e92fa805bc272d7f587898bb8b68c4d5d7938db884abaa76e15c";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProverVersion {
+    V1_0_1 {
+        verifier_digest: &'static str,
+    },
+    #[cfg(test)]
+    UnsupportedVersion,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProverVersionError {
+    UnsupportedVersion,
+}
+
+impl Default for ProverVersion {
+    fn default() -> Self {
+        VERSION_V1_0_1
+    }
+}
+
+impl TryFrom<FBSProverVersion> for ProverVersion {
+    type Error = ProverVersionError;
+
+    fn try_from(prover_version: FBSProverVersion) -> Result<Self, Self::Error> {
+        match prover_version {
+            FBSProverVersion::V1_0_1 => Ok(VERSION_V1_0_1),
+            _ => Err(ProverVersionError::UnsupportedVersion),
+        }
+    }
+}
+
+impl TryInto<FBSProverVersion> for ProverVersion {
+    type Error = ProverVersionError;
+
+    fn try_into(self) -> Result<FBSProverVersion, Self::Error> {
+        // this is to allow for a future error where a version is missed
+        #[allow(unreachable_patterns)]
+        match self {
+            ProverVersion::V1_0_1 { .. } => Ok(FBSProverVersion::V1_0_1),
+            _ => Err(ProverVersionError::UnsupportedVersion),
+        }
+    }
+}
+
+pub const VERSION_V1_0_1: ProverVersion = ProverVersion::V1_0_1 {
+    verifier_digest: DIGEST_V1_0_1_BYTES,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_version() {
+        assert_eq!(ProverVersion::default(), VERSION_V1_0_1);
+    }
+
+    #[test]
+    fn test_verify_prover_version() {
+        assert_eq!(
+            VERSION_V1_0_1,
+            ProverVersion::V1_0_1 {
+                verifier_digest: DIGEST_V1_0_1_BYTES
+            }
+        );
+    }
+
+    #[test]
+    fn test_try_from_v1_0_1() {
+        let version = ProverVersion::try_from(FBSProverVersion::V1_0_1);
+        assert!(version.is_ok());
+        assert_eq!(version.unwrap(), VERSION_V1_0_1);
+    }
+
+    #[test]
+    fn test_try_into_v1_0_1() {
+        let fbs_version: Result<FBSProverVersion, ProverVersionError> = VERSION_V1_0_1.try_into();
+        assert!(fbs_version.is_ok());
+        assert_eq!(fbs_version.unwrap(), FBSProverVersion::V1_0_1);
+    }
+
+    #[test]
+    fn test_try_from_unsupported_version() {
+        let unsupported_version = FBSProverVersion(u16::MAX);
+        let version = ProverVersion::try_from(unsupported_version);
+        assert!(version.is_err());
+        assert_eq!(version.unwrap_err(), ProverVersionError::UnsupportedVersion);
+    }
+
+    #[test]
+    fn test_try_into_unsupported_version() {
+        let unsupported_version = ProverVersion::UnsupportedVersion;
+        let fbs_version: Result<FBSProverVersion, ProverVersionError> =
+            unsupported_version.try_into();
+        assert!(fbs_version.is_err());
+        assert_eq!(
+            fbs_version.unwrap_err(),
+            ProverVersionError::UnsupportedVersion
+        );
+    }
+}

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -8,7 +8,6 @@ publish = false          # Exclude local crates from licensing checks
 anyhow = "1.0.86"
 async-trait = "0.1.80"
 bincode = "1.3.3"
-bonsol-schema = { path = "../schemas-rust" }
 bytes = "1.5.0"
 futures-util = "0.3.30"
 reqwest = { version = "0.11.26", features = [
@@ -25,6 +24,8 @@ solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-sdk = { workspace = true }
 tokio = "1.36.0"
+
+bonsol-schema.workspace = true
 
 [dev-dependencies]
 mockito = "1.5.0"

--- a/schemas/execution_request_v1.fbs
+++ b/schemas/execution_request_v1.fbs
@@ -1,5 +1,16 @@
 include "./input_type.fbs";
 
+enum ProverVersion: uint16 {
+    V1_0_1 = 0,
+    V1_0_2 = 1,
+    V1_0_3 = 2,
+    V1_0_4 = 3,
+    V1_0_5 = 4,
+    V1_1_0 = 5,
+    V1_1_1 = 6,
+    V1_1_2 = 7,
+}
+
 struct Account (force_align: 8) {
   writable: uint8;
   pubkey: [uint8:32];
@@ -17,6 +28,7 @@ table ExecutionRequestV1{
   input_digest: [uint8]; // sha256 of the input data, checked against journal digest
   max_block_height: uint64; // max block height to accept prover commitment
   callback_extra_accounts: [Account] (force_align: 8); // extra accounts to pass to callback program 
+  prover_version: ProverVersion = V1_0_1;
 }
 
 root_type ExecutionRequestV1;

--- a/schemas/execution_request_v1.fbs
+++ b/schemas/execution_request_v1.fbs
@@ -1,14 +1,15 @@
 include "./input_type.fbs";
 
 enum ProverVersion: uint16 {
-    V1_0_1 = 0,
-    V1_0_2 = 1,
-    V1_0_3 = 2,
-    V1_0_4 = 3,
-    V1_0_5 = 4,
-    V1_1_0 = 5,
-    V1_1_1 = 6,
-    V1_1_2 = 7,
+    DEFAULT = 0,
+    V1_0_1 = 1,
+    V1_0_2 = 2,
+    V1_0_3 = 3,
+    V1_0_4 = 4,
+    V1_0_5 = 5,
+    V1_1_0 = 6,
+    V1_1_1 = 7,
+    V1_1_2 = 8,
 }
 
 struct Account (force_align: 8) {
@@ -28,7 +29,7 @@ table ExecutionRequestV1{
   input_digest: [uint8]; // sha256 of the input data, checked against journal digest
   max_block_height: uint64; // max block height to accept prover commitment
   callback_extra_accounts: [Account] (force_align: 8); // extra accounts to pass to callback program 
-  prover_version: ProverVersion = V1_0_1;
+  prover_version: ProverVersion = DEFAULT;
 }
 
 root_type ExecutionRequestV1;

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -8,7 +8,6 @@ publish = false          # Exclude local crates from licensing checks
 anyhow = "1.0.86"
 async-trait = "0.1.80"
 bincode = "1.3.3"
-bonsol-interface = { path = "../onchain/interface", features = ["default"] }
 bytes = "1.5.0"
 flatbuffers = { workspace = true }
 futures-util = "0.3.30"
@@ -27,3 +26,6 @@ solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-sdk = { workspace = true }
 tokio = "1.36.0"
+
+bonsol-interface.workspace = true
+bonsol-schema.workspace = true

--- a/tester/Cargo.toml
+++ b/tester/Cargo.toml
@@ -5,11 +5,13 @@ edition = "2021"
 publish = false          # Exclude local crates from licensing checks
 
 [dependencies]
-bonsol-sdk = { path = "../sdk" }
-bonsol-cli = { path = "../cli" }
-solana-sdk = { workspace = true }
-solana-rpc-client = { workspace = true }
-solana-rpc-client-api = { workspace = true }
+bonsol-interface.workspace = true
+bonsol-sdk.workspace = true
+bonsol-cli.workspace = true
+solana-sdk.workspace = true
+solana-rpc-client.workspace = true
+solana-rpc-client-api.workspace = true
+
 anyhow = "1.0.91"
 rand = "0.8.5"
 tokio = "1.41.0"

--- a/tester/src/main.rs
+++ b/tester/src/main.rs
@@ -1,9 +1,10 @@
+use std::str::FromStr;
+
 use anyhow::Result;
 
-use bonsol_sdk::instructions::{CallbackConfig, ExecutionConfig, InputRef};
-use bonsol_sdk::{deployment_address, execution_address, BonsolClient, ExitCode, InputType};
 use rand::distributions::Alphanumeric;
 use rand::Rng;
+
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_rpc_client_api::config::RpcSendTransactionConfig;
 use solana_sdk::commitment_config::CommitmentConfig;
@@ -16,7 +17,9 @@ use solana_sdk::signer::Signer;
 use solana_sdk::system_program;
 use solana_sdk::transaction::VersionedTransaction;
 
-use std::str::FromStr;
+use bonsol_interface::prover_version::ProverVersion;
+use bonsol_sdk::instructions::{CallbackConfig, ExecutionConfig, InputRef};
+use bonsol_sdk::{deployment_address, execution_address, BonsolClient, ExitCode, InputType};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -75,6 +78,7 @@ async fn example_sdk_test(
                     AccountMeta::new_readonly(ea3, false),
                 ],
             }),
+            Some(ProverVersion::default()),
         )
         .await?;
     let bh = client.get_latest_blockhash().await?;

--- a/testing-examples/example-execution-request.json
+++ b/testing-examples/example-execution-request.json
@@ -1,5 +1,5 @@
 {
-  "imageId": "68f4b0c5f9ce034aa60ceb264a18d6c410a3af68fafd931bcfd9ebe7c1e42960",
+  "imageId": "058530737d1b86e43ed2529f114b85195c27290fcf0844623b1ccb14934e8218",
   "executionConfig": {
     "verifyInputHash": false,
     "forwardOutput": true

--- a/testing-examples/example-execution-request.json
+++ b/testing-examples/example-execution-request.json
@@ -1,5 +1,5 @@
 {
-  "imageId": "058530737d1b86e43ed2529f114b85195c27290fcf0844623b1ccb14934e8218",
+  "imageId": "68f4b0c5f9ce034aa60ceb264a18d6c410a3af68fafd931bcfd9ebe7c1e42960",
   "executionConfig": {
     "verifyInputHash": false,
     "forwardOutput": true


### PR DESCRIPTION
closes #29

This introduces a feature to manage risc0 versions.   Each prover node will only prove from client execution requests that are sent to it from a compatible version of the client.    

- [x] client requests are tagged with a specific version
- [x] mismatching versions are ignored at execution time
- [x] logging is provided for incompatible versions
- [x] changes are tested

Related Issues
* #85 
* #32
* #87