### PR TITLE
fix: Remove version requirement for cargo-binstall from install.sh

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-cargo install cargo-binstall@1.0.1
+cargo install cargo-binstall
 cargo binstall cargo-risczero
 cargo risczero install
 


### PR DESCRIPTION
Ref #95 