### PR TITLE
fix: Add optional S3 endpoint to upload arguments

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -100,6 +100,14 @@ pub struct S3UploadArgs {
         env = "AWS_REGION"
     )]
     pub region: String,
+
+    #[arg(
+        help = "Specify the AWS S3 compatibility endpoint",
+        long,
+        required = false,
+        env = "AWS_S3_ENDPOINT"
+    )]
+    pub endpoint: Option<String>,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/cli/src/deploy.rs
+++ b/cli/src/deploy.rs
@@ -60,11 +60,8 @@ pub async fn deploy(rpc_url: String, signer: Keypair, deploy_args: DeployArgs) -
             let dest =
             object_store::path::Path::from(format!("{}-{}", manifest.name, manifest.image_id));
 
-            let url = if let Some(endpoint) = endpoint {
-                format!("{}", endpoint)
-            } else {
-                format!("https://{}.s3.{}.amazonaws.com/{}", bucket, region, dest)
-            };
+            let url = endpoint.unwrap_or(
+                format!("https://{}.s3.{}.amazonaws.com/{}", bucket, region, dest));
 
             let s3_client = AmazonS3Builder::new()
                 .with_bucket_name(&bucket)

--- a/cli/src/deploy.rs
+++ b/cli/src/deploy.rs
@@ -71,7 +71,7 @@ pub async fn deploy(rpc_url: String, signer: Keypair, deploy_args: DeployArgs) -
                 .with_region(&region)
                 .with_access_key_id(&access_key)
                 .with_secret_access_key(&secret_key)
-                .with_url(&url)
+                .with_endpoint(&url)
                 .build()
                 .map_err(|err| {
                     BonsolCliError::S3ClientError(S3ClientError::FailedToBuildClient {


### PR DESCRIPTION
### Description  
Add an optional `endpoint` field in the `S3UploadArgs` struct. Users can now specify a custom AWS S3-compatible endpoint, enhancing the deployment function's flexibility for working with different S3-compatible services.  

The changes include:  
1. Modifying the `S3UploadArgs` struct to include an `endpoint` field.  
2. Updating the deployment logic to use the provided `endpoint` if specified.  
3. Defaulting to the standard S3 URL format when the `endpoint` field is not provided.  
4. Updating the `AmazonS3Builder` configuration to incorporate the custom endpoint.

---

### Testing  
- **Case 1: Without `endpoint` field**  
  Input:  
  ```bash
    bonsol deploy --deploy-type <DEPLOY_TYPE> --bucket <BUCKET> --access-key <ACCESS_KEY> --secret-key <SECRET_KEY> --region <REGION> --url <URL> --manifest-path <MANIFEST_PATH> <--create|--storage-account <STORAGE_ACCOUNT>>
  ```  
  Expected: URL defaults to `https://example-bucket.s3.us-west-1.amazonaws.com/...`.  

- **Case 2: With `endpoint` field**  
  Input:  
  ```bash
   bonsol deploy --deploy-type <DEPLOY_TYPE> --bucket <BUCKET> --access-key <ACCESS_KEY> --secret-key <SECRET_KEY> --region <REGION> --url <URL> --manifest-path <MANIFEST_PATH> <--create|--storage-account <STORAGE_ACCOUNT>> --endpoint https://custom-s3-endpoint.com/...
  ```  
  Expected: URL uses the custom endpoint `https://custom-s3-endpoint.com/...`.  

---

### Checklist  
- [x] Added `endpoint` field to `S3UploadArgs`.  
- [x] Updated `AmazonS3Builder` logic for custom endpoint.  
- [x] Tested with and without the `endpoint` field.  

---

### Related Issues  
- Resolves #108 

### References
- https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html#method.with_endpoint