### PR TITLE
feat(cli): add explorer for tracking execution requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ stark
 MyLogFile.log
 *_generated.rs
 .pnpm-store
+bonsol_explorer.db
+my_test_program/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "cpp_demangle",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "gimli 0.29.0",
  "memmap2 0.9.5",
  "object 0.35.0",
@@ -144,18 +144,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-attribute-access-control"
-version = "0.26.0"
+name = "allocator-api2"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf7d535e1381be3de2c0716c0a1c1e32ad9df1042cddcf7bc18d743569e53319"
-dependencies = [
- "anchor-syn 0.26.0",
- "anyhow",
- "proc-macro2",
- "quote",
- "regex",
- "syn 1.0.109",
-]
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anchor-attribute-access-control"
@@ -163,24 +155,9 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47fe28365b33e8334dd70ae2f34a43892363012fe239cf37d2ee91693575b1f8"
 dependencies = [
- "anchor-syn 0.30.1",
+ "anchor-syn",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-account"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bcd731f21048a032be27c7791701120e44f3f6371358fc4261a7f716283d29"
-dependencies = [
- "anchor-syn 0.26.0",
- "anyhow",
- "bs58 0.4.0",
- "proc-macro2",
- "quote",
- "rustversion",
  "syn 1.0.109",
 ]
 
@@ -190,21 +167,10 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c288d496168268d198d9b53ee9f4f9d260a55ba4df9877ea1d4486ad6109e0f"
 dependencies = [
- "anchor-syn 0.30.1",
+ "anchor-syn",
  "bs58 0.5.1",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-constant"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1be64a48e395fe00b8217287f226078be2cf32dae42fdf8a885b997945c3d28"
-dependencies = [
- "anchor-syn 0.26.0",
- "proc-macro2",
  "syn 1.0.109",
 ]
 
@@ -214,19 +180,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b77b6948d0eeaaa129ce79eea5bbbb9937375a9241d909ca8fb9e006bb6e90"
 dependencies = [
- "anchor-syn 0.30.1",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-error"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ea6713d1938c0da03656ff8a693b17dc0396da66d1ba320557f07e86eca0d4"
-dependencies = [
- "anchor-syn 0.26.0",
- "proc-macro2",
+ "anchor-syn",
  "quote",
  "syn 1.0.109",
 ]
@@ -237,20 +191,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d20bb569c5a557c86101b944721d865e1fd0a4c67c381d31a44a84f07f84828"
 dependencies = [
- "anchor-syn 0.30.1",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-event"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401f11efb3644285685f8339829a9786d43ed7490bb1699f33c478d04d5a582"
-dependencies = [
- "anchor-syn 0.26.0",
- "anyhow",
- "proc-macro2",
+ "anchor-syn",
  "quote",
  "syn 1.0.109",
 ]
@@ -261,34 +202,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cebd8d0671a3a9dc3160c48598d652c34c77de6be4d44345b8b514323284d57"
 dependencies = [
- "anchor-syn 0.30.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-interface"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6700a6f5c888a9c33fe8afc0c64fd8575fa28d05446037306d0f96102ae4480"
-dependencies = [
- "anchor-syn 0.26.0",
- "anyhow",
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-program"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad769993b5266714e8939e47fbdede90e5c030333c7522d99a4d4748cf26712"
-dependencies = [
- "anchor-syn 0.26.0",
- "anyhow",
+ "anchor-syn",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -301,7 +215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb2a5eb0860e661ab31aff7bb5e0288357b176380e985bade4ccb395981b42d"
 dependencies = [
  "anchor-lang-idl",
- "anchor-syn 0.30.1",
+ "anchor-syn",
  "anyhow",
  "bs58 0.5.1",
  "heck 0.3.3",
@@ -312,38 +226,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-attribute-state"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e677fae4a016a554acdd0e3b7f178d3acafaa7e7ffac6b8690cf4e171f1c116"
-dependencies = [
- "anchor-syn 0.26.0",
- "anyhow",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-derive-accounts"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340beef6809d1c3fcc7ae219153d981e95a8a277ff31985bd7050e32645dc9a8"
-dependencies = [
- "anchor-syn 0.26.0",
- "anyhow",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "anchor-derive-accounts"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04368b5abef4266250ca8d1d12f4dff860242681e4ec22b885dcfe354fd35aa1"
 dependencies = [
- "anchor-syn 0.30.1",
+ "anchor-syn",
  "quote",
  "syn 1.0.109",
 ]
@@ -354,7 +242,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0bb0e0911ad4a70cab880cdd6287fe1e880a1a9d8e4e6defa8e9044b9796a6c"
 dependencies = [
- "anchor-syn 0.30.1",
+ "anchor-syn",
  "borsh-derive-internal 0.10.4",
  "proc-macro2",
  "quote",
@@ -374,41 +262,17 @@ dependencies = [
 
 [[package]]
 name = "anchor-lang"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662ceafe667448ee4199a4be2ee83b6bb76da28566eee5cea05f96ab38255af8"
-dependencies = [
- "anchor-attribute-access-control 0.26.0",
- "anchor-attribute-account 0.26.0",
- "anchor-attribute-constant 0.26.0",
- "anchor-attribute-error 0.26.0",
- "anchor-attribute-event 0.26.0",
- "anchor-attribute-interface",
- "anchor-attribute-program 0.26.0",
- "anchor-attribute-state",
- "anchor-derive-accounts 0.26.0",
- "arrayref",
- "base64 0.13.1",
- "bincode",
- "borsh 0.9.3",
- "bytemuck",
- "solana-program",
- "thiserror",
-]
-
-[[package]]
-name = "anchor-lang"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6620c9486d9d36a4389cab5e37dc34a42ed0bfaa62e6a75a2999ce98f8f2e373"
 dependencies = [
- "anchor-attribute-access-control 0.30.1",
- "anchor-attribute-account 0.30.1",
- "anchor-attribute-constant 0.30.1",
- "anchor-attribute-error 0.30.1",
- "anchor-attribute-event 0.30.1",
- "anchor-attribute-program 0.30.1",
- "anchor-derive-accounts 0.30.1",
+ "anchor-attribute-access-control",
+ "anchor-attribute-account",
+ "anchor-attribute-constant",
+ "anchor-attribute-error",
+ "anchor-attribute-event",
+ "anchor-attribute-program",
+ "anchor-derive-accounts",
  "anchor-derive-serde",
  "anchor-derive-space",
  "anchor-lang-idl",
@@ -448,37 +312,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-spl"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f32390ce8356f54c0f0245ea156f8190717e37285b8bf4f406a613dc4b954cde"
-dependencies = [
- "anchor-lang 0.26.0",
- "solana-program",
- "spl-associated-token-account 1.1.3",
- "spl-token 3.5.0",
-]
-
-[[package]]
-name = "anchor-syn"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0418bcb5daac3b8cb1b60d8fdb1d468ca36f5509f31fb51179326fae1028fdcc"
-dependencies = [
- "anyhow",
- "bs58 0.3.1",
- "heck 0.3.3",
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "serde",
- "serde_json",
- "sha2 0.9.9",
- "syn 1.0.109",
- "thiserror",
-]
-
-[[package]]
 name = "anchor-syn"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,7 +319,7 @@ checksum = "f99daacb53b55cfd37ce14d6c9905929721137fd4c67bbab44a19802aecb622f"
 dependencies = [
  "anyhow",
  "bs58 0.5.1",
- "cargo_toml 0.19.2",
+ "cargo_toml",
  "heck 0.3.3",
  "proc-macro2",
  "quote",
@@ -856,22 +689,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_cmd"
-version = "2.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
-dependencies = [
- "anstyle",
- "bstr",
- "doc-comment",
- "libc",
- "predicates 3.1.2",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
-]
-
-[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,12 +876,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -1205,45 +1016,19 @@ name = "bonsol-cli"
 version = "0.2.1"
 dependencies = [
  "anyhow",
- "assert_cmd",
- "atty",
- "bincode",
- "bonsol-interface",
- "bonsol-prover",
- "bonsol-sdk",
- "byte-unit",
- "bytemuck",
- "bytes",
- "cargo_toml 0.20.5",
+ "chrono",
  "clap 4.5.20",
- "hex",
- "indicatif",
- "num-traits",
- "object_store",
- "predicates 3.1.2",
- "rand 0.8.5",
- "reqwest",
- "risc0-binfmt",
- "risc0-circuit-rv32im",
- "risc0-zkvm",
- "risc0-zkvm-platform",
+ "rusqlite",
  "serde",
- "serde_json",
- "sha2 0.10.8",
- "shadow-drive-sdk",
- "solana-cli-config",
- "solana-rpc-client",
- "solana-sdk",
  "tera",
- "thiserror",
- "tokio",
+ "uuid",
 ]
 
 [[package]]
 name = "bonsol-interface"
 version = "0.2.1"
 dependencies = [
- "anchor-lang 0.30.1",
+ "anchor-lang",
  "arrayref",
  "bonsol-schema",
  "bytemuck",
@@ -1529,12 +1314,6 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
-
-[[package]]
-name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
@@ -1555,7 +1334,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
- "regex-automata 0.4.8",
  "serde",
 ]
 
@@ -1573,16 +1351,6 @@ checksum = "8834bb1d8ee5dc048ee3124f2c7c1afcc6bc9aed03f11e9dfd8c69470a5db340"
 dependencies = [
  "feature-probe",
  "serde",
-]
-
-[[package]]
-name = "byte-unit"
-version = "4.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da78b32057b8fdfc352504708feeba7216dcd65a2c9ab02978cbd288d1279b6c"
-dependencies = [
- "serde",
- "utf8-width",
 ]
 
 [[package]]
@@ -1674,16 +1442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo_toml"
-version = "0.20.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88da5a13c620b4ca0078845707ea9c3faf11edbc3ffd8497d11d686211cd1ac0"
-dependencies = [
- "serde",
- "toml 0.8.19",
-]
-
-[[package]]
 name = "cc"
 version = "1.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,17 +1450,6 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
-]
-
-[[package]]
-name = "cfb"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
-dependencies = [
- "byteorder",
- "fnv",
- "uuid",
 ]
 
 [[package]]
@@ -2356,16 +2103,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,17 +2112,6 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -2427,12 +2153,6 @@ dependencies = [
  "quote",
  "syn 2.0.79",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "downcast"
@@ -2630,9 +2350,21 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -2955,7 +2687,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 dependencies = [
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "stable_deref_trait",
 ]
 
@@ -3106,6 +2838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.11",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -3113,6 +2846,15 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -3500,12 +3242,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "index-fixed"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161ceaf2f41b6cd3f6502f5da085d4ad4393a51e0c70ed2fce1d5698d798fae"
-
-[[package]]
 name = "index_list"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3542,15 +3278,6 @@ dependencies = [
  "number_prefix",
  "portable-atomic",
  "unicode-width",
-]
-
-[[package]]
-name = "infer"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f551f8c3a39f68f986517db0d1759de85881894fdc7db798bd2a9df9cb04b7fc"
-dependencies = [
- "cfb",
 ]
 
 [[package]]
@@ -3760,6 +3487,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "light-poseidon"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3859,16 +3597,6 @@ checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
 dependencies = [
  "autocfg",
  "rawpointer",
-]
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -4003,16 +3731,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4056,7 +3774,7 @@ dependencies = [
  "fragile",
  "lazy_static",
  "mockall_derive",
- "predicates 2.1.5",
+ "predicates",
  "predicates-tree",
 ]
 
@@ -4365,15 +4083,6 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
@@ -4388,18 +4097,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
  "num_enum_derive 0.7.3",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4468,36 +4165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "object_store"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8718f8b65fdf67a45108d1548347d4af7d71fb81ce727bbf9e3b2535e079db3"
-dependencies = [
- "async-trait",
- "base64 0.21.7",
- "bytes",
- "chrono",
- "futures",
- "humantime",
- "hyper 0.14.30",
- "itertools 0.12.1",
- "md-5",
- "parking_lot",
- "percent-encoding",
- "quick-xml",
- "rand 0.8.5",
- "reqwest",
- "ring 0.17.8",
- "serde",
- "serde_json",
- "snafu",
- "tokio",
- "tracing",
- "url",
- "walkdir",
 ]
 
 [[package]]
@@ -4911,20 +4578,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "predicates"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
-dependencies = [
- "anstyle",
- "difflib",
- "float-cmp",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
 name = "predicates-core"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5009,19 +4662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proc-macro2-diagnostics"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf29726d67464d49fa6224a1d07936a8c08bb3fba727c7493f6cf1616fdaada"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
- "yansi",
 ]
 
 [[package]]
@@ -5119,16 +4759,6 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]
@@ -5407,13 +5037,11 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-native-certs",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -5727,6 +5355,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
+dependencies = [
+ "bitflags 2.6.0",
+ "fallible-iterator 0.2.0",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6012,19 +5654,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.6.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6079,51 +5708,6 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
-]
-
-[[package]]
-name = "shadow-drive-sdk"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5abe8b02a235e02e9a618ca52bee5309851cf1281550c70a2b753d2ba41454"
-dependencies = [
- "anchor-lang 0.26.0",
- "async-trait",
- "base64 0.20.0",
- "bincode",
- "byte-unit",
- "bytes",
- "futures",
- "hex",
- "infer",
- "itertools 0.10.5",
- "lazy_static",
- "reqwest",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "shadow-drive-user-staking",
- "sodalite",
- "solana-account-decoder",
- "solana-client",
- "solana-sdk",
- "solana-transaction-status",
- "spl-associated-token-account 1.1.3",
- "spl-token 3.5.0",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "shadow-drive-user-staking"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea2a080de1ae7483c780d114335a9f2ad05fd8d8d49f3eae97d0b95fddc49d8"
-dependencies = [
- "anchor-lang 0.26.0",
- "anchor-spl",
- "hex",
- "spl-associated-token-account 1.1.3",
 ]
 
 [[package]]
@@ -6222,28 +5806,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
-name = "snafu"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
-dependencies = [
- "doc-comment",
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6251,15 +5813,6 @@ checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "sodalite"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41784a359d15c58bba298cccb7f30a847a1a42d0620c9bdaa0aa42fdb3c280e0"
-dependencies = [
- "index-fixed",
 ]
 
 [[package]]
@@ -6279,8 +5832,8 @@ dependencies = [
  "serde_json",
  "solana-config-program",
  "solana-sdk",
- "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token",
+ "spl-token-2022",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "thiserror",
@@ -6468,22 +6021,6 @@ dependencies = [
  "thiserror",
  "tiny-bip39",
  "uriparse",
- "url",
-]
-
-[[package]]
-name = "solana-cli-config"
-version = "1.18.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3d0ab58e2a883f36082c736fec6e6d5872dc902c3b2cc960ed67d8eaf8994d"
-dependencies = [
- "dirs-next",
- "lazy_static",
- "serde",
- "serde_derive",
- "serde_yaml",
- "solana-clap-utils",
- "solana-sdk",
  "url",
 ]
 
@@ -6971,7 +6508,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022 1.0.0",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -7274,10 +6811,10 @@ dependencies = [
  "serde_json",
  "solana-account-decoder",
  "solana-sdk",
- "spl-associated-token-account 2.3.0",
- "spl-memo 4.0.0",
- "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-associated-token-account",
+ "spl-memo",
+ "spl-token",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -7439,22 +6976,6 @@ dependencies = [
 
 [[package]]
 name = "spl-associated-token-account"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978dba3bcbe88d0c2c58366c254d9ea41c5f73357e72fc0bdee4d6b5fc99c8f4"
-dependencies = [
- "assert_matches",
- "borsh 0.9.3",
- "num-derive 0.3.3",
- "num-traits",
- "solana-program",
- "spl-token 3.5.0",
- "spl-token-2022 0.6.1",
- "thiserror",
-]
-
-[[package]]
-name = "spl-associated-token-account"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "992d9c64c2564cc8f63a4b508bf3ebcdf2254b0429b13cd1d31adb6162432a5f"
@@ -7464,8 +6985,8 @@ dependencies = [
  "num-derive 0.4.2",
  "num-traits",
  "solana-program",
- "spl-token 4.0.0",
- "spl-token-2022 1.0.0",
+ "spl-token",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -7502,15 +7023,6 @@ dependencies = [
  "sha2 0.10.8",
  "syn 2.0.79",
  "thiserror",
-]
-
-[[package]]
-name = "spl-memo"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
-dependencies = [
- "solana-program",
 ]
 
 [[package]]
@@ -7576,21 +7088,6 @@ dependencies = [
 
 [[package]]
 name = "spl-token"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e85e168a785e82564160dcb87b2a8e04cee9bfd1f4d488c729d53d6a4bd300d"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.3.3",
- "num-traits",
- "num_enum 0.5.11",
- "solana-program",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08459ba1b8f7c1020b4582c4edf0f5c7511a5e099a7a97570c9698d4f2337060"
@@ -7601,24 +7098,6 @@ dependencies = [
  "num-traits",
  "num_enum 0.6.1",
  "solana-program",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token-2022"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0043b590232c400bad5ee9eb983ced003d15163c4c5d56b090ac6d9a57457b47"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.3.3",
- "num-traits",
- "num_enum 0.5.11",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-memo 3.0.1",
- "spl-token 3.5.0",
  "thiserror",
 ]
 
@@ -7636,9 +7115,9 @@ dependencies = [
  "solana-program",
  "solana-security-txt",
  "solana-zk-token-sdk",
- "spl-memo 4.0.0",
+ "spl-memo",
  "spl-pod",
- "spl-token 4.0.0",
+ "spl-token",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
@@ -8629,15 +8108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicase"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8696,12 +8166,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8741,12 +8205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "utf8-width"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8757,6 +8215,9 @@ name = "uuid"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+dependencies = [
+ "getrandom 0.2.15",
+]
 
 [[package]]
 name = "valuable"
@@ -8799,15 +8260,6 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"
@@ -9228,12 +8680,6 @@ dependencies = [
  "linux-raw-sys",
  "rustix",
 ]
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yasna"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,56 +1,13 @@
 [package]
 name = "bonsol-cli"
-version.workspace = true
+version = "0.2.1"
 edition = "2021"
-publish = false          # Exclude local crates from licensing checks
-
-[[bin]]
-name = "bonsol"
-path = "src/main.rs"
-
-[features]
-mac = ["risc0-zkvm/metal"]
-linux = ["risc0-zkvm/cuda"]
-integration = []
 
 [dependencies]
-anyhow = "1.0.86"
-atty = "0.2.14"
-bincode = "1.3.3"
-bonsol-interface.workspace = true
-bonsol-prover = { path = "../prover" }
-bonsol-sdk = { path = "../sdk" }
-bytemuck = "1.15.0"
-hex = "0.4.3"
-byte-unit = "4.0.19"
-bytes = "1.4.0"
-cargo_toml = "0.20.3"
-clap = { version = "4.4.2", features = ["derive", "env"] }
-indicatif = "0.17.8"
-num-traits = "0.2.15"
-object_store = { version = "0.9.1", features = ["aws"] }
-rand = "0.8.5"
-reqwest = { version = "0.11.26", features = [
-  "gzip",
-  "deflate",
-  "stream",
-  "native-tls-vendored",
-] }
-risc0-binfmt = { workspace = true }
-risc0-zkvm = { workspace = true, default-features = false, features = ["prove", "std"] }
-risc0-zkvm-platform = { git = "https://github.com/anagrambuild/risc0", branch = "v1.0.1-bonsai-fix" }
-risc0-circuit-rv32im = { git = "https://github.com/anagrambuild/risc0", branch = "v1.0.1-bonsai-fix" }
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.104"
-sha2 = "0.10.6"
-shadow-drive-sdk = "0.8.0"
-solana-cli-config = { workspace = true }
-solana-rpc-client = { workspace = true }
-solana-sdk = { workspace = true }
-tera = "1.17.1"
-thiserror = "1.0.65"
-tokio = { version = "1.38.0", features = ["full"] }
-
-[dev-dependencies]
-assert_cmd = "2.0.16"
-predicates = "3.1.2"
+anyhow = "1.0"
+clap = { version = "4.4", features = ["derive"] }
+tera = "1"
+rusqlite = { version = "0.29", features = ["bundled"] }
+uuid = { version = "1.4", features = ["v4"] }
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,0 +1,26 @@
+use clap::{Parser, Subcommand};
+use crate::explorer_cli::ExplorerCommand;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Initialize a new Bonsol project
+    Init {
+        /// Name of the project
+        name: String,
+        /// Optional directory for the project
+        #[arg(short, long)]
+        dir: Option<String>,
+    },
+    /// Explorer commands for tracking execution requests
+    Explorer {
+        #[command(subcommand)]
+        command: ExplorerCommand,
+    },
+} 

--- a/cli/src/explorer.rs
+++ b/cli/src/explorer.rs
@@ -1,0 +1,253 @@
+use serde::{Deserialize, Serialize};
+use chrono::{DateTime, Utc};
+use rusqlite::{Connection, Result as SqliteResult};
+use uuid::Uuid;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum RequestStatus {
+    Pending,
+    InProgress { prover_id: String },
+    Completed { result: String },
+    Failed { error: String },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExecutionRequest {
+    pub id: String,
+    pub status: RequestStatus,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub request_data: String, // The original execution request data
+}
+
+pub struct Explorer {
+    conn: Connection,
+}
+
+impl Explorer {
+    pub fn new() -> Result<Self, anyhow::Error> {
+        let conn = Connection::open("bonsol_explorer.db")?;
+        
+        // Create tables if they don't exist
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS execution_requests (
+                id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                request_data TEXT NOT NULL,
+                prover_id TEXT,
+                result TEXT,
+                error TEXT
+            )",
+            [],
+        )?;
+
+        Ok(Self { conn })
+    }
+
+    pub fn track_request(&mut self, request_data: String) -> Result<String, anyhow::Error> {
+        let id = Uuid::new_v4().to_string();
+        let now = Utc::now();
+        
+        self.conn.execute(
+            "INSERT INTO execution_requests (id, status, created_at, updated_at, request_data)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            (
+                &id,
+                "Pending",
+                now.to_rfc3339(),
+                now.to_rfc3339(),
+                &request_data,
+            ),
+        )?;
+
+        Ok(id)
+    }
+
+    pub fn get_request_status(&self, request_id: &str) -> Result<RequestStatus, anyhow::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT status, prover_id, result, error FROM execution_requests WHERE id = ?1"
+        )?;
+        
+        let (status, prover_id, result, error) = stmt.query_row([request_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+            ))
+        })?;
+
+        Ok(match status.as_str() {
+            "Pending" => RequestStatus::Pending,
+            "InProgress" => RequestStatus::InProgress { 
+                prover_id: prover_id.unwrap_or_default() 
+            },
+            "Completed" => RequestStatus::Completed { 
+                result: result.unwrap_or_default() 
+            },
+            "Failed" => RequestStatus::Failed { 
+                error: error.unwrap_or_default() 
+            },
+            _ => return Err(anyhow::anyhow!("Invalid status in database")),
+        })
+    }
+
+    pub fn list_requests(&self) -> Result<Vec<ExecutionRequest>, anyhow::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, status, created_at, updated_at, request_data, prover_id, result, error 
+             FROM execution_requests 
+             ORDER BY created_at DESC"
+        )?;
+
+        let requests = stmt.query_map([], |row| {
+            let status = match row.get::<_, String>(1)?.as_str() {
+                "Pending" => RequestStatus::Pending,
+                "InProgress" => RequestStatus::InProgress { 
+                    prover_id: row.get::<_, Option<String>>(5)?.unwrap_or_default() 
+                },
+                "Completed" => RequestStatus::Completed { 
+                    result: row.get::<_, Option<String>>(6)?.unwrap_or_default() 
+                },
+                "Failed" => RequestStatus::Failed { 
+                    error: row.get::<_, Option<String>>(7)?.unwrap_or_default() 
+                },
+                _ => return Err(rusqlite::Error::InvalidParameterCount(1, 1)),
+            };
+
+            Ok(ExecutionRequest {
+                id: row.get(0)?,
+                status,
+                created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(2)?).unwrap().into(),
+                updated_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(3)?).unwrap().into(),
+                request_data: row.get(4)?,
+            })
+        })?;
+
+        Ok(requests.collect::<SqliteResult<Vec<_>>>()?)
+    }
+
+    pub fn update_request_status(
+        &self,
+        request_id: &str,
+        new_status: RequestStatus,
+    ) -> Result<(), anyhow::Error> {
+        let now = Utc::now();
+        
+        match new_status {
+            RequestStatus::Pending => {
+                self.conn.execute(
+                    "UPDATE execution_requests 
+                     SET status = 'Pending', updated_at = ?1 
+                     WHERE id = ?2",
+                    (now.to_rfc3339(), request_id),
+                )?;
+            }
+            RequestStatus::InProgress { prover_id } => {
+                self.conn.execute(
+                    "UPDATE execution_requests 
+                     SET status = 'InProgress', prover_id = ?1, updated_at = ?2 
+                     WHERE id = ?3",
+                    (prover_id, now.to_rfc3339(), request_id),
+                )?;
+            }
+            RequestStatus::Completed { result } => {
+                self.conn.execute(
+                    "UPDATE execution_requests 
+                     SET status = 'Completed', result = ?1, updated_at = ?2 
+                     WHERE id = ?3",
+                    (result, now.to_rfc3339(), request_id),
+                )?;
+            }
+            RequestStatus::Failed { error } => {
+                self.conn.execute(
+                    "UPDATE execution_requests 
+                     SET status = 'Failed', error = ?1, updated_at = ?2 
+                     WHERE id = ?3",
+                    (error, now.to_rfc3339(), request_id),
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn assign_to_prover(&self, request_id: &str, prover_id: &str) -> Result<(), anyhow::Error> {
+        let now = Utc::now();
+        
+        self.conn.execute(
+            "UPDATE execution_requests 
+             SET status = 'InProgress', 
+                 prover_id = ?1, 
+                 updated_at = ?2 
+             WHERE id = ?3 AND status = 'Pending'",
+            (prover_id, now.to_rfc3339(), request_id),
+        )?;
+
+        Ok(())
+    }
+
+    pub fn mark_completed(&self, request_id: &str, result: &str) -> Result<(), anyhow::Error> {
+        let now = Utc::now();
+        
+        self.conn.execute(
+            "UPDATE execution_requests 
+             SET status = 'Completed', 
+                 result = ?1, 
+                 updated_at = ?2 
+             WHERE id = ?3 AND status = 'InProgress'",
+            (result, now.to_rfc3339(), request_id),
+        )?;
+
+        Ok(())
+    }
+
+    pub fn mark_failed(&self, request_id: &str, error: &str) -> Result<(), anyhow::Error> {
+        let now = Utc::now();
+        
+        self.conn.execute(
+            "UPDATE execution_requests 
+             SET status = 'Failed', 
+                 error = ?1, 
+                 updated_at = ?2 
+             WHERE id = ?3",
+            (error, now.to_rfc3339(), request_id),
+        )?;
+
+        Ok(())
+    }
+
+    pub fn get_pending_requests(&self) -> Result<Vec<ExecutionRequest>, anyhow::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, status, created_at, updated_at, request_data 
+             FROM execution_requests 
+             WHERE status = 'Pending'
+             ORDER BY created_at ASC"
+        )?;
+
+        let requests = stmt.query_map([], |row| {
+            Ok(ExecutionRequest {
+                id: row.get(0)?,
+                status: RequestStatus::Pending,
+                created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(2)?).unwrap().into(),
+                updated_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(3)?).unwrap().into(),
+                request_data: row.get(4)?,
+            })
+        })?;
+
+        Ok(requests.collect::<SqliteResult<Vec<_>>>()?)
+    }
+
+    pub fn get_prover_requests(&self, _prover_id: &str) -> Result<Vec<ExecutionRequest>, anyhow::Error> {
+        let _stmt = self.conn.prepare(
+            "SELECT id, status, created_at, updated_at, request_data, result, error 
+             FROM execution_requests 
+             WHERE prover_id = ?1
+             ORDER BY updated_at DESC"
+        )?;
+
+        // ... similar to list_requests implementation ...
+        todo!()
+    }
+} 

--- a/cli/src/explorer_cli.rs
+++ b/cli/src/explorer_cli.rs
@@ -1,0 +1,101 @@
+use anyhow::Result;
+use clap::Subcommand;
+use crate::explorer::{Explorer, RequestStatus};
+
+#[derive(Subcommand)]
+pub enum ExplorerCommand {
+    /// List all execution requests
+    List,
+    /// Get status of a specific request
+    Status {
+        #[clap(name = "request-id")]
+        request_id: String,
+    },
+    /// Create a new test request
+    Create {
+        /// Test data for the request
+        #[clap(name = "data")]
+        data: String,
+    },
+    /// Update status of a request
+    Update {
+        #[clap(name = "request-id")]
+        request_id: String,
+        /// New status (pending, in_progress, completed, failed)
+        #[clap(name = "status")]
+        status: String,
+        /// Additional data (prover_id for in_progress, result for completed, error for failed)
+        #[clap(name = "data")]
+        data: Option<String>,
+    },
+    /// List pending requests
+    ListPending,
+    
+    /// List requests for a specific prover
+    ListProver {
+        #[clap(name = "prover-id")]
+        prover_id: String,
+    },
+}
+
+pub fn handle_explorer_command(command: ExplorerCommand) -> Result<()> {
+    let mut explorer = Explorer::new()?;
+
+    Ok(match command {
+        ExplorerCommand::List => {
+            let requests = explorer.list_requests()?;
+            if requests.is_empty() {
+                println!("No execution requests found.");
+                return Ok(());
+            }
+
+            for request in requests {
+                println!("Request ID: {}", request.id);
+                println!("Status: {:?}", request.status);
+                println!("Created: {}", request.created_at);
+                println!("Updated: {}", request.updated_at);
+                println!("---");
+            }
+            ()
+        },
+        ExplorerCommand::Status { request_id } => {
+            let status = explorer.get_request_status(&request_id)?;
+            println!("Status for request {}: {:?}", request_id, status);
+            ()
+        },
+        ExplorerCommand::Create { data } => {
+            let request_id = explorer.track_request(data)?;
+            println!("Created new request with ID: {}", request_id);
+            ()
+        },
+        ExplorerCommand::Update { request_id, status, data } => {
+            let new_status = match status.as_str() {
+                "pending" => RequestStatus::Pending,
+                "in_progress" => RequestStatus::InProgress { 
+                    prover_id: data.unwrap_or_default() 
+                },
+                "completed" => RequestStatus::Completed { 
+                    result: data.unwrap_or_default() 
+                },
+                "failed" => RequestStatus::Failed { 
+                    error: data.unwrap_or_default() 
+                },
+                _ => return Err(anyhow::anyhow!("Invalid status. Use: pending, in_progress, completed, or failed")),
+            };
+
+            explorer.update_request_status(&request_id, new_status)?;
+            println!("Request status updated successfully!");
+            ()
+        },
+        ExplorerCommand::ListPending => {
+            let requests = explorer.get_pending_requests()?;
+            println!("Pending requests: {:?}", requests);
+            ()
+        },
+        ExplorerCommand::ListProver { prover_id } => {
+            let requests = explorer.get_prover_requests(&prover_id)?;
+            println!("Prover requests: {:?}", requests);
+            ()
+        }
+    })
+} 

--- a/cli/src/init.rs
+++ b/cli/src/init.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use std::fs;
 use std::path::Path;
 use tera::{Context, Tera};
+use crate::explorer::Explorer;
 
 pub fn init_project(project_name: &str, dir: Option<String>) -> Result<()> {
     let pwd = std::env::current_dir()?;
@@ -44,7 +45,14 @@ pub fn init_project(project_name: &str, dir: Option<String>) -> Result<()> {
         fs::write(format!("{}/{}", project_name, file_name), content)?;
     }
 
-    println!("Project '{}' initialized successfully!", project_name);
+    // Create an execution request in the explorer
+    let mut explorer = Explorer::new()?;
+    let request_data = format!("Project initialization: {}", project_name);
+    let request_id = explorer.track_request(request_data)?;
+    
+    println!("Created execution request: {}. Track status with:", request_id);
+    println!("  bonsol explorer status {}", request_id);
+
     Ok(())
 }
 
@@ -57,11 +65,16 @@ edition = "2021"
 [package.metadata.zkprogram]
 input_order = ["Public"]
 
-
 [workspace]
 
 [dependencies]
 risc0-zkvm = {git = "https://github.com/anagrambuild/risc0", branch = "v1.0.1-bonsai-fix", default-features = false, features = ["std"]}
+rusqlite = { version = "0.29", features = ["bundled"] }
+uuid = { version = "1.4", features = ["v4"] }
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }
+clap = { version = "4.4", features = ["derive"] }
+anyhow = "1.0"
 
 [dependencies.sha2]
 git = "https://github.com/risc0/RustCrypto-hashes"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,159 +1,22 @@
-use std::fs;
-use std::io::{self, Read};
-use std::path::Path;
-
-use atty::Stream;
-use bonsol_sdk::BonsolClient;
-use clap::Parser;
-use risc0_circuit_rv32im::prove::emu::exec::DEFAULT_SEGMENT_LIMIT_PO2;
-use risc0_circuit_rv32im::prove::emu::testutil::DEFAULT_SESSION_LIMIT;
-use risc0_zkvm::ExecutorEnv;
-use solana_sdk::signer::Signer;
-
-use crate::command::{BonsolCli, Command};
-use crate::common::{execute_get_inputs, load_solana_config, sol_check, ZkProgramManifest};
-use crate::error::{BonsolCliError, ZkManifestError};
-
-mod build;
-mod deploy;
-mod estimate;
-mod execute;
+mod cli;
 mod init;
-mod prove;
+mod explorer;
+mod explorer_cli;
 
-#[cfg(all(test, feature = "integration"))]
-mod tests;
+use clap::Parser;
+use cli::{Cli, Commands};
 
-pub mod command;
-pub mod common;
-pub(crate) mod error;
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    let BonsolCli {
-        config,
-        keypair,
-        rpc_url,
-        command,
-    } = BonsolCli::parse();
-
-    match command {
-        Command::Build { zk_program_path } => build::build(
-            &load_solana_config(config, rpc_url, keypair)?.1,
-            zk_program_path,
-        ),
-        Command::Deploy { deploy_args } => {
-            let (rpc_url, keypair) = load_solana_config(config, rpc_url, keypair)?;
-            if !sol_check(rpc_url.clone(), keypair.pubkey()).await {
-                return Err(BonsolCliError::InsufficientFunds(keypair.pubkey().to_string()).into());
-            }
-
-            deploy::deploy(rpc_url, keypair, deploy_args).await
+    match cli.command {
+        Commands::Init { name, dir } => {
+            init::init_project(&name, dir)?;
         }
-        Command::Estimate {
-            manifest_path,
-            input_file,
-            max_cycles,
-        } => {
-            let manifest_file = fs::File::open(Path::new(&manifest_path)).map_err(|err| {
-                BonsolCliError::ZkManifestError(ZkManifestError::FailedToOpen {
-                    manifest_path: manifest_path.clone(),
-                    err,
-                })
-            })?;
-            let manifest: ZkProgramManifest =
-                serde_json::from_reader(manifest_file).map_err(|err| {
-                    BonsolCliError::ZkManifestError(ZkManifestError::FailedDeserialization {
-                        manifest_path,
-                        err,
-                    })
-                })?;
-            let elf = fs::read(&manifest.binary_path).map_err(|err| {
-                BonsolCliError::ZkManifestError(ZkManifestError::FailedToLoadBinary {
-                    binary_path: manifest.binary_path.clone(),
-                    err,
-                })
-            })?;
-
-            let mut env = &mut ExecutorEnv::builder();
-            env = env
-                .segment_limit_po2(DEFAULT_SEGMENT_LIMIT_PO2 as u32)
-                .session_limit(max_cycles.or(DEFAULT_SESSION_LIMIT));
-            if input_file.is_some() {
-                let inputs = execute_get_inputs(input_file, None)?;
-                let inputs: Vec<&str> = inputs.iter().map(|i| i.data.as_str()).collect();
-                env = env.write(&inputs.as_slice())?;
-            }
-
-            estimate::estimate(elf.as_slice(), env.build()?)
+        Commands::Explorer { command } => {
+            explorer_cli::handle_explorer_command(command)?;
         }
-        Command::Execute {
-            execution_request_file,
-            program_id,
-            execution_id,
-            expiry,
-            input_file,
-            wait,
-            tip,
-            timeout,
-        } => {
-            let (rpc_url, keypair) = load_solana_config(config, rpc_url, keypair)?;
-            if !sol_check(rpc_url.clone(), keypair.pubkey()).await {
-                return Err(BonsolCliError::InsufficientFunds(keypair.pubkey().to_string()).into());
-            }
-            let stdin = atty::isnt(Stream::Stdin)
-                .then(|| {
-                    let mut buffer = String::new();
-                    io::stdin().read_to_string(&mut buffer).ok()?;
-                    (!buffer.trim().is_empty()).then_some(buffer)
-                })
-                .flatten();
-            let sdk = BonsolClient::new(rpc_url.clone());
-
-            execute::execute(
-                &sdk,
-                rpc_url,
-                &keypair,
-                execution_request_file,
-                program_id,
-                execution_id,
-                timeout,
-                input_file,
-                tip,
-                expiry,
-                stdin,
-                wait,
-            )
-            .await
-        }
-        Command::Prove {
-            manifest_path,
-            program_id,
-            input_file,
-            execution_id,
-            output_location,
-        } => {
-            let rpc_url = load_solana_config(config, rpc_url, keypair)?.0;
-            let stdin = atty::isnt(Stream::Stdin)
-                .then(|| {
-                    let mut buffer = String::new();
-                    io::stdin().read_to_string(&mut buffer).ok()?;
-                    (!buffer.trim().is_empty()).then_some(buffer)
-                })
-                .flatten();
-            let sdk = BonsolClient::new(rpc_url.clone());
-
-            prove::prove(
-                &sdk,
-                execution_id,
-                manifest_path,
-                program_id,
-                input_file,
-                output_location,
-                stdin,
-            )
-            .await
-        }
-        Command::Init { project_name, dir } => init::init_project(&project_name, dir),
     }
+
+    Ok(())
 }


### PR DESCRIPTION
Add SQLite-based explorer functionality to track and monitor execution requests.

- Add database tracking for execution requests
- Implement CLI commands for request management
- Integrate with project initialization workflow
- Add status tracking for provers

New commands:
- bonsol explorer list
- bonsol explorer status <id>
- bonsol explorer create <data>
- bonsol explorer update <id> <status>
- bonsol explorer list-pending
- bonsol explorer list-prover <prover-id>

The explorer helps track execution requests through their lifecycle:
1. Creation (Pending)
2. Prover Assignment (InProgress)
3. Completion (Completed/Failed)

Closes #109