### PR TITLE
refactor: prepare bonsol-schema for publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ version = "0.3.0"
 dependencies = [
  "anchor-lang",
  "bonsol-interface",
- "bonsol-schema 0.3.3",
+ "bonsol-schema 0.3.4",
  "paste",
 ]
 
@@ -1041,10 +1041,10 @@ dependencies = [
 
 [[package]]
 name = "bonsol-interface"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "arrayref",
- "bonsol-schema 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bonsol-schema 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytemuck",
  "flatbuffers",
  "hex",
@@ -1126,7 +1126,7 @@ dependencies = [
  "arrayref",
  "async-trait",
  "bincode",
- "bonsol-schema 0.3.3",
+ "bonsol-schema 0.3.4",
  "bytes",
  "futures-util",
  "mockito",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "bonsol-schema"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "bytemuck",
  "flatbuffers",
@@ -1155,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "bonsol-schema"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e92397482e39ef486a74688aed16159a3497704a43a57fb42833bd4eebed8b1"
+checksum = "0ea6dd31ebf298a14d1a5111e40c836ca9ac4ce230e3649be703846b2c1ce23f"
 dependencies = [
  "bytemuck",
  "flatbuffers",
@@ -1174,7 +1174,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bonsol-interface",
- "bonsol-schema 0.3.3",
+ "bonsol-schema 0.3.4",
  "bytes",
  "flatbuffers",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "bonsol-schema"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "bytemuck",
  "flatbuffers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ version = "0.3.0"
 dependencies = [
  "anchor-lang",
  "bonsol-interface",
- "bonsol-schema",
+ "bonsol-schema 0.3.3",
  "paste",
 ]
 
@@ -1041,10 +1041,10 @@ dependencies = [
 
 [[package]]
 name = "bonsol-interface"
-version = "0.3.0"
+version = "0.3.3"
 dependencies = [
  "arrayref",
- "bonsol-schema",
+ "bonsol-schema 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytemuck",
  "flatbuffers",
  "hex",
@@ -1126,7 +1126,7 @@ dependencies = [
  "arrayref",
  "async-trait",
  "bincode",
- "bonsol-schema",
+ "bonsol-schema 0.3.3",
  "bytes",
  "futures-util",
  "mockito",
@@ -1144,7 +1144,20 @@ dependencies = [
 
 [[package]]
 name = "bonsol-schema"
-version = "0.3.2"
+version = "0.3.3"
+dependencies = [
+ "bytemuck",
+ "flatbuffers",
+ "num-derive 0.3.3",
+ "num-traits",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "bonsol-schema"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e92397482e39ef486a74688aed16159a3497704a43a57fb42833bd4eebed8b1"
 dependencies = [
  "bytemuck",
  "flatbuffers",
@@ -1161,7 +1174,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bonsol-interface",
- "bonsol-schema",
+ "bonsol-schema 0.3.3",
  "bytes",
  "flatbuffers",
  "futures-util",

--- a/node/src/risc0_runner/mod.rs
+++ b/node/src/risc0_runner/mod.rs
@@ -636,7 +636,7 @@ async fn handle_image_deployment<'a>(
     loaded_images: LoadedImageMapRef<'a>,
 ) -> Result<()> {
     let url = deploy.url().ok_or(Risc0RunnerError::InvalidData)?;
-    let size = deploy.size_();
+    let size = deploy.size();
     emit_histogram!(MetricEvents::ImageDownload, size as f64, url => url.to_string());
     emit_event_with_duration!(MetricEvents::ImageDownload, {
         let resp = http_client.get(url).send().await?.error_for_status()?;

--- a/onchain/interface/Cargo.toml
+++ b/onchain/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bonsol-interface"
-version.workspace = true
+version = "0.3.3"
 edition = "2021"
 publish = false           # Exclude local crates from licensing checks
 

--- a/onchain/interface/Cargo.toml
+++ b/onchain/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bonsol-interface"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 publish = false           # Exclude local crates from licensing checks
 
@@ -18,6 +18,6 @@ sha3 = "0.10.8"
 solana-program = { workspace = true, optional = true }
 solana-sdk = { workspace = true, optional = true }
 thiserror = { workspace = true }
-bonsol-schema = "0.3.3"
+bonsol-schema = "0.3.4"
 
 [dev-dependencies]

--- a/onchain/interface/Cargo.toml
+++ b/onchain/interface/Cargo.toml
@@ -18,6 +18,6 @@ sha3 = "0.10.8"
 solana-program = { workspace = true, optional = true }
 solana-sdk = { workspace = true, optional = true }
 thiserror = { workspace = true }
-bonsol-schema.workspace = true
+bonsol-schema = { version = "0.3.3", path = "../schemas-rust" }
 
 [dev-dependencies]

--- a/onchain/interface/Cargo.toml
+++ b/onchain/interface/Cargo.toml
@@ -18,6 +18,6 @@ sha3 = "0.10.8"
 solana-program = { workspace = true, optional = true }
 solana-sdk = { workspace = true, optional = true }
 thiserror = { workspace = true }
-bonsol-schema = { version = "0.3.3", path = "../schemas-rust" }
+bonsol-schema = "0.3.3"
 
 [dev-dependencies]

--- a/onchain/interface/src/instructions.rs
+++ b/onchain/interface/src/instructions.rs
@@ -48,7 +48,7 @@ pub fn deploy_v1(
             image_id: Some(image_id),
             program_name: Some(name),
             url: Some(url),
-            size: image_size,
+            size_: image_size,
             inputs: Some(fb_inputs),
         },
     );

--- a/onchain/interface/src/instructions.rs
+++ b/onchain/interface/src/instructions.rs
@@ -48,7 +48,7 @@ pub fn deploy_v1(
             image_id: Some(image_id),
             program_name: Some(name),
             url: Some(url),
-            size_: image_size,
+            size: image_size,
             inputs: Some(fb_inputs),
         },
     );

--- a/schemas-rust/Cargo.toml
+++ b/schemas-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bonsol-schema"
-version = "0.3.3"
+version = "0.3.4"
 description = "Bonsol types, schema definitions"
 authors = ["anagram build team"]
 repository = "https://github.com/anagrambuild/bonsol"

--- a/schemas-rust/Cargo.toml
+++ b/schemas-rust/Cargo.toml
@@ -1,18 +1,23 @@
 [package]
 name = "bonsol-schema"
-version.workspace = true
+version = "0.3.3"
 description = "Bonsol types, schema definitions"
 authors = ["anagram build team"]
 repository = "https://github.com/anagrambuild/bonsol"
 license = "MIT"
 edition = "2021"
+include = [
+    "src/**/*",
+    "build.rs",
+    "schemas/*.fbs"
+]
 
 [dependencies]
 bytemuck = "1.7.2"
-flatbuffers = { workspace = true }
+flatbuffers = "24.3.25"
 num-derive = "0.3.3"
 num-traits = "0.2.15"
-thiserror = { workspace = true }
+thiserror = "1.0.57"
 
 [lints.rust]
 unused_imports = "allow"

--- a/schemas-rust/build.rs
+++ b/schemas-rust/build.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
-    // Define schema directory and target directory for generated Rust code.
-    let schema_dir = Path::new("../schemas");
+    // Schema files are now in a local 'schemas' directory
+    let schema_dir = Path::new("schemas");
     let generated_src =
         PathBuf::from(env::var("GENERATED_CODE_DIR").unwrap_or_else(|_| "src".to_string()));
 

--- a/schemas-rust/schemas/channel_instruction.fbs
+++ b/schemas-rust/schemas/channel_instruction.fbs
@@ -1,0 +1,20 @@
+include "./execution_request_v1.fbs"; 
+include "./status_v1.fbs";
+include "./deploy_v1.fbs";
+include "./claim_v1.fbs";
+
+enum ChannelInstructionIxType: uint8 {
+  ExecuteV1 = 0,
+  StatusV1 = 1,
+  DeployV1 = 2,
+  ClaimV1 = 3,
+  //4 is reserved for InputSet which is removed
+}
+table ChannelInstruction{
+  ix_type: ChannelInstructionIxType;
+  execute_v1: [ubyte] (nested_flatbuffer: "ExecutionRequestV1");
+  status_v1: [ubyte] (nested_flatbuffer: "StatusV1");
+  deploy_v1: [ubyte] (nested_flatbuffer: "DeployV1");
+  claim_v1: [ubyte] (nested_flatbuffer: "ClaimV1");
+}
+root_type ChannelInstruction;

--- a/schemas-rust/schemas/claim_v1.fbs
+++ b/schemas-rust/schemas/claim_v1.fbs
@@ -1,0 +1,7 @@
+table ClaimV1 {
+  execution_id: string;
+  block_commitment: uint64;
+  //maybe some cool mpc decryption keys here or something
+}
+
+root_type ClaimV1;

--- a/schemas-rust/schemas/deploy_v1.fbs
+++ b/schemas-rust/schemas/deploy_v1.fbs
@@ -6,7 +6,7 @@ table DeployV1 {
   image_id: string; //digest of the program elf file
   program_name: string;
   url: string; //url to the program elf file probbaly on ipfs/arweave/other 
-  size: uint64; //size of the program elf file
+  size_: uint64; //size of the program elf file
   inputs: [ProgramInputType]; //loaded into the program in array order
 }
 

--- a/schemas-rust/schemas/deploy_v1.fbs
+++ b/schemas-rust/schemas/deploy_v1.fbs
@@ -1,0 +1,13 @@
+include "./input_type.fbs";
+
+// programs are immutable and are identified by their id which is a digest of the program elf file
+table DeployV1 {
+  owner: [uint8]; //owner of the program duplicated here since its better to copy 32 bytes than to have to cow thew whole struct
+  image_id: string; //digest of the program elf file
+  program_name: string;
+  url: string; //url to the program elf file probbaly on ipfs/arweave/other 
+  size: uint64; //size of the program elf file
+  inputs: [ProgramInputType]; //loaded into the program in array order
+}
+
+root_type DeployV1;

--- a/schemas-rust/schemas/execution_request_v1.fbs
+++ b/schemas-rust/schemas/execution_request_v1.fbs
@@ -1,0 +1,29 @@
+include "./input_type.fbs";
+
+enum ProverVersion: uint16 {
+    DEFAULT = 0,
+    V1_0_1 = 1,
+    V1_2_1 = 9,
+}
+
+struct Account (force_align: 8) {
+  writable: uint8;
+  pubkey: [uint8:32];
+}
+
+table ExecutionRequestV1{
+  tip: uint64;
+  execution_id: string;
+  image_id: string;
+  callback_program_id: [uint8];
+  callback_instruction_prefix: [uint8];
+  forward_output: bool = false;
+  verify_input_hash: bool = true;
+  input: [Input];
+  input_digest: [uint8]; // sha256 of the input data, checked against journal digest
+  max_block_height: uint64; // max block height to accept prover commitment
+  callback_extra_accounts: [Account] (force_align: 8); // extra accounts to pass to callback program 
+  prover_version: ProverVersion = DEFAULT;
+}
+
+root_type ExecutionRequestV1;

--- a/schemas-rust/schemas/input_type.fbs
+++ b/schemas-rust/schemas/input_type.fbs
@@ -1,0 +1,21 @@
+enum ProgramInputType: uint8 {
+  Unknown = 0,
+  Public = 1,
+  Private = 2,
+  PublicProof = 3,
+}
+
+enum InputType: uint8 {
+  Unknown = 0,
+  PublicData = 1,
+  PublicAccountData = 3,
+  PublicUrl = 4,
+  Private = 5, // only used for local proving
+  PublicProof = 7,
+  PrivateLocal = 8
+}
+
+table Input {
+  input_type: InputType = 1;
+  data: [uint8];
+}

--- a/schemas-rust/schemas/status_v1.fbs
+++ b/schemas-rust/schemas/status_v1.fbs
@@ -1,0 +1,20 @@
+enum StatusTypes: uint8 {
+  Unknown = 0,
+  Queued = 1,
+  Claimed = 2,
+  Completed = 3,
+  Failed = 4,
+}
+
+table StatusV1{
+  execution_id: string;
+  status: StatusTypes;
+  proof: [uint8];
+  execution_digest: [uint8];
+  input_digest: [uint8];
+  committed_outputs: [uint8];
+  assumption_digest: [uint8];
+  exit_code_system: uint32;
+  exit_code_user: uint32;
+}
+root_type StatusV1;


### PR DESCRIPTION
- Move schema files into schemas-rust/schemas for self-contained packaging

- Update build script to use local schemas directory

- Fix size_ to size field name in flatbuffers generated code

- Update version to 0.3.3 for publishing