### PR TITLE
chore: prepare crates for publishing to crates.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ stark
 MyLogFile.log
 *_generated.rs
 .pnpm-store
+flatbuffers/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,7 +977,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bonsol"
-version = "0.3.0"
+version = "0.3.5"
 dependencies = [
  "ark-bn254",
  "ark-serialize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,7 +1011,7 @@ dependencies = [
  "bincode",
  "bonsol-interface 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bonsol-prover 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "bonsol-sdk",
+ "bonsol-sdk 0.3.5",
  "byte-unit",
  "bytemuck",
  "bytes",
@@ -1211,7 +1211,33 @@ dependencies = [
 
 [[package]]
 name = "bonsol-sdk"
-version = "0.3.0"
+version = "0.3.5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "bonsol-interface 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bonsol-schema 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "flatbuffers",
+ "futures-util",
+ "num-traits",
+ "reqwest 0.11.27",
+ "risc0-binfmt",
+ "risc0-zkvm",
+ "serde",
+ "serde_json",
+ "solana-rpc-client",
+ "solana-rpc-client-api",
+ "solana-sdk",
+ "tokio",
+]
+
+[[package]]
+name = "bonsol-sdk"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f33050cac13d3d661e47fb20bd94c418bb56e87eb618b017a4909bad6ac2dd70"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1240,7 +1266,7 @@ dependencies = [
  "anyhow",
  "bonsol-cli",
  "bonsol-interface 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "bonsol-sdk",
+ "bonsol-sdk 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "solana-rpc-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
  "atty",
  "bincode",
  "bonsol-interface 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "bonsol-prover",
+ "bonsol-prover 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bonsol-sdk",
  "byte-unit",
  "bytemuck",
@@ -1088,7 +1088,7 @@ dependencies = [
  "ark-std",
  "async-trait",
  "bonsol-interface 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "bonsol-prover",
+ "bonsol-prover 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytemuck",
  "byteorder",
  "bytes",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "bonsol-prover"
-version = "0.3.0"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -1148,6 +1148,31 @@ dependencies = [
  "bytes",
  "futures-util",
  "mockito",
+ "reqwest 0.11.27",
+ "risc0-binfmt",
+ "risc0-zkvm",
+ "serde",
+ "serde_json",
+ "solana-account-decoder",
+ "solana-rpc-client",
+ "solana-rpc-client-api",
+ "solana-sdk",
+ "tokio",
+]
+
+[[package]]
+name = "bonsol-prover"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ff65c2dc6a2808f53d723b58782d72d7317bacca269c41f4290e78c55f6bdcc"
+dependencies = [
+ "anyhow",
+ "arrayref",
+ "async-trait",
+ "bincode",
+ "bonsol-schema 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "futures-util",
  "reqwest 0.11.27",
  "risc0-binfmt",
  "risc0-zkvm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,7 +981,7 @@ version = "0.3.0"
 dependencies = [
  "ark-bn254",
  "ark-serialize",
- "bonsol-interface",
+ "bonsol-interface 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flatbuffers",
  "groth16-solana",
  "hex",
@@ -996,7 +996,7 @@ name = "bonsol-anchor-interface"
 version = "0.3.0"
 dependencies = [
  "anchor-lang",
- "bonsol-interface",
+ "bonsol-interface 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bonsol-schema 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste",
 ]
@@ -1009,7 +1009,7 @@ dependencies = [
  "assert_cmd",
  "atty",
  "bincode",
- "bonsol-interface",
+ "bonsol-interface 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bonsol-prover",
  "bonsol-sdk",
  "byte-unit",
@@ -1041,7 +1041,25 @@ dependencies = [
 
 [[package]]
 name = "bonsol-interface"
-version = "0.3.0"
+version = "0.3.5"
+dependencies = [
+ "arrayref",
+ "bonsol-schema 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytemuck",
+ "flatbuffers",
+ "hex",
+ "serde",
+ "sha3 0.10.8",
+ "solana-program 2.0.23",
+ "solana-sdk",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "bonsol-interface"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26442126f1e156d03978977e51ae82d16c76aefe62bb2dea76c8500baa15a6d"
 dependencies = [
  "arrayref",
  "bonsol-schema 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1069,7 +1087,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "async-trait",
- "bonsol-interface",
+ "bonsol-interface 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bonsol-prover",
  "bytemuck",
  "byteorder",
@@ -1173,7 +1191,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
- "bonsol-interface",
+ "bonsol-interface 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bonsol-schema 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "flatbuffers",
@@ -1196,7 +1214,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bonsol-cli",
- "bonsol-interface",
+ "bonsol-interface 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bonsol-sdk",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -1431,7 +1449,7 @@ dependencies = [
 name = "callback-example"
 version = "0.3.0"
 dependencies = [
- "bonsol-interface",
+ "bonsol-interface 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-program 2.0.23",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ version = "0.3.0"
 dependencies = [
  "anchor-lang",
  "bonsol-interface",
- "bonsol-schema",
+ "bonsol-schema 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste",
 ]
 
@@ -1044,7 +1044,7 @@ name = "bonsol-interface"
 version = "0.3.0"
 dependencies = [
  "arrayref",
- "bonsol-schema",
+ "bonsol-schema 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytemuck",
  "flatbuffers",
  "hex",
@@ -1126,7 +1126,7 @@ dependencies = [
  "arrayref",
  "async-trait",
  "bincode",
- "bonsol-schema",
+ "bonsol-schema 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "futures-util",
  "mockito",
@@ -1144,7 +1144,20 @@ dependencies = [
 
 [[package]]
 name = "bonsol-schema"
-version = "0.3.0"
+version = "0.3.5"
+dependencies = [
+ "bytemuck",
+ "flatbuffers",
+ "num-derive 0.3.3",
+ "num-traits",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "bonsol-schema"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc095aee568d4d6df65369a5c832078d3dcd27ff40b1dd1b210dabfb0308758a"
 dependencies = [
  "bytemuck",
  "flatbuffers",
@@ -1161,7 +1174,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bonsol-interface",
- "bonsol-schema",
+ "bonsol-schema 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "flatbuffers",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "bonsol-cli"
-version = "0.3.0"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1011,7 +1011,7 @@ dependencies = [
  "bincode",
  "bonsol-interface 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bonsol-prover 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "bonsol-sdk 0.3.5",
+ "bonsol-sdk 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-unit",
  "bytemuck",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ risc0-zkvm-platform = { version = "1.2.1" }
 risc0-circuit-rv32im = { version = "1.2.1" }
 risc0-circuit-recursion-sys = { version = "1.2.1" }
 tokio-test = "0.4.3"
-bonsol-interface = { path = "./onchain/interface" }
+bonsol-interface = "0.3.5"
 bonsol-schema = "0.3.5"
 bonsol-cli = { path = "./cli" }
 bonsol-sdk = { path = "./sdk" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ risc0-circuit-rv32im = { version = "1.2.1" }
 risc0-circuit-recursion-sys = { version = "1.2.1" }
 tokio-test = "0.4.3"
 bonsol-interface = { path = "./onchain/interface" }
-bonsol-schema = { path = "./schemas-rust" }
+bonsol-schema = "0.3.5"
 bonsol-cli = { path = "./cli" }
 bonsol-sdk = { path = "./sdk" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tokio-test = "0.4.3"
 bonsol-interface = "0.3.5"
 bonsol-schema = "0.3.5"
 bonsol-cli = { path = "./cli" }
-bonsol-sdk = { path = "./sdk" }
+bonsol-sdk = "0.3.5"
 
 [patch.crates-io.curve25519-dalek] 
  git = "https://github.com/anza-xyz/curve25519-dalek.git" 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,8 +17,8 @@ integration-tests = []
 anyhow = "1.0.86"
 atty = "0.2.14"
 bincode = "1.3.3"
-bonsol-interface.workspace = true
-bonsol-prover = { path = "../prover" }
+bonsol-interface = "0.3.5"
+bonsol-prover = "0.3.5"
 bonsol-sdk = { path = "../sdk" }
 bytemuck = "1.15.0"
 hex = "0.4.3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,7 @@ atty = "0.2.14"
 bincode = "1.3.3"
 bonsol-interface = "0.3.5"
 bonsol-prover = "0.3.5"
-bonsol-sdk = { path = "../sdk" }
+bonsol-sdk = "0.3.5"
 bytemuck = "1.15.0"
 hex = "0.4.3"
 byte-unit = "4.0.19"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -21,7 +21,7 @@ ark-relations = { version = "0.4.0" }
 ark-serialize = "0.4.0"
 ark-std = { version = "0.4.0" }
 async-trait = "0.1.80"
-bonsol-interface = { workspace = true }
+bonsol-interface = "0.3.5"
 bonsol-prover = { path = "../prover" }
 bytemuck = "1.15.0"
 byteorder = "1.5.0"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -22,7 +22,7 @@ ark-serialize = "0.4.0"
 ark-std = { version = "0.4.0" }
 async-trait = "0.1.80"
 bonsol-interface = "0.3.5"
-bonsol-prover = { path = "../prover" }
+bonsol-prover = "0.3.5"
 bytemuck = "1.15.0"
 byteorder = "1.5.0"
 bytes = "1.5.0"

--- a/onchain/anchor-interface/Cargo.toml
+++ b/onchain/anchor-interface/Cargo.toml
@@ -10,8 +10,8 @@ idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
 anchor-lang = ">=0.28"
-bonsol-schema.workspace = true
-bonsol-interface = {workspace = true, features = ["on-chain"], default-features = false}
+bonsol-schema = "0.3.5"
+bonsol-interface = { version = "0.3.5", features = ["on-chain"], default-features = false }
 paste = "1.0.12"
 
 

--- a/onchain/bonsol/Cargo.toml
+++ b/onchain/bonsol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bonsol"
-version.workspace = true
-description = "Solana channel to bonsai"
+version = "0.3.5"
+description = "Solana channel to Bonsol"
 authors = ["anagram build team"]
 repository = "https://github.com/anagrambuild/bonsol"
 license = "MIT"
@@ -20,14 +20,12 @@ test-sbf = []
 [dependencies]
 ark-bn254 = "0.4.0"
 ark-serialize = "0.4.0"
-bonsol-interface = { version = "0.3.5", features = [
-  "on-chain",
-], default-features = false }
-flatbuffers = { workspace = true }
-groth16-solana = { version = "0.0.2" }
+bonsol-interface = { version = "0.3.5", features = ["on-chain"], default-features = false }
+flatbuffers = "24.3.25"
+groth16-solana = "0.0.2"
 hex = "0.4.2"
 hex-literal = "0.4.1"
 num-bigint = "0.4.4"
-solana-program = { workspace = true }
-thiserror = { workspace = true }
+solana-program = "~2.0"
+thiserror = "1.0.57"
 

--- a/onchain/bonsol/Cargo.toml
+++ b/onchain/bonsol/Cargo.toml
@@ -20,7 +20,7 @@ test-sbf = []
 [dependencies]
 ark-bn254 = "0.4.0"
 ark-serialize = "0.4.0"
-bonsol-interface = { path = "../interface", features = [
+bonsol-interface = { version = "0.3.5", features = [
   "on-chain",
 ], default-features = false }
 flatbuffers = { workspace = true }

--- a/onchain/example-program-on-bonsol/Cargo.toml
+++ b/onchain/example-program-on-bonsol/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 test-sbf = []
 
 [dependencies]
-bonsol-interface = { path = "../interface", features = [
+bonsol-interface = { version = "0.3.5", features = [
   "on-chain",
 ], default-features = false }
 solana-program = { workspace = true }

--- a/onchain/interface/Cargo.toml
+++ b/onchain/interface/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "bonsol-interface"
-version.workspace = true
+version = "0.3.5"  
+description = "Interface definitions for Bonsol"
+authors = ["anagram build team"]
+repository = "https://github.com/anagrambuild/bonsol"
+license = "MIT"
 edition = "2021"
-publish = false           # Exclude local crates from licensing checks
 
 [features]
 on-chain = ["solana-program"]
@@ -11,13 +14,13 @@ default = ["solana-sdk", "serde"]
 [dependencies]
 arrayref = "0.3.6"
 bytemuck = { version = "1.15.0", features = ["derive"] }
-flatbuffers = { workspace = true }
+flatbuffers = "24.3.25"
 hex = "0.4.3"
 serde = { version = "1.0.197", optional = true }
 sha3 = "0.10.8"
-solana-program = { workspace = true, optional = true }
-solana-sdk = { workspace = true, optional = true }
-thiserror = { workspace = true }
+solana-program = { version = "~2.0", optional = true }
+solana-sdk = { version = "~2.0", optional = true }
+thiserror = "1.0.57"
 bonsol-schema = "0.3.5"
 
 [dev-dependencies]

--- a/onchain/interface/Cargo.toml
+++ b/onchain/interface/Cargo.toml
@@ -18,6 +18,6 @@ sha3 = "0.10.8"
 solana-program = { workspace = true, optional = true }
 solana-sdk = { workspace = true, optional = true }
 thiserror = { workspace = true }
-bonsol-schema.workspace = true
+bonsol-schema = "0.3.5"
 
 [dev-dependencies]

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,13 +1,18 @@
 [package]
 name = "bonsol-prover"
-version.workspace = true
+version = "0.3.5"
+description = "Zero-knowledge proof generation for Bonsol"
+authors = ["anagram build team"]
+repository = "https://github.com/anagrambuild/bonsol"
+license = "MIT"
 edition = "2021"
-publish = false          # Exclude local crates from licensing checks
 
 [dependencies]
 anyhow = "1.0.86"
 async-trait = "0.1.80"
+arrayref = "0.3.6"
 bincode = "1.3.3"
+bonsol-schema = "0.3.5"
 bytes = "1.5.0"
 futures-util = "0.3.30"
 reqwest = { version = "0.11.26", features = [
@@ -16,17 +21,15 @@ reqwest = { version = "0.11.26", features = [
   "stream",
   "native-tls-vendored",
 ] }
-risc0-binfmt = { workspace = true }
-risc0-zkvm = { workspace = true }
+risc0-binfmt = "1.2.1"
+risc0-zkvm = { version = "1.2.1", features = ["prove"], default-features = false }
 serde = { version = "1.0.197" }
 serde_json = "1.0.104"
-solana-rpc-client = { workspace = true }
-solana-rpc-client-api = { workspace = true }
-solana-account-decoder = { workspace = true }
-solana-sdk = { workspace = true }
+solana-rpc-client = "~2.0"
+solana-rpc-client-api = "~2.0"
+solana-account-decoder = "~2.0"
+solana-sdk = "~2.0"
 tokio = "1.36.0"
-arrayref = "0.3.6"
-bonsol-schema.workspace = true
 
 [dev-dependencies]
 mockito = "1.5.0"

--- a/schemas-rust/Cargo.toml
+++ b/schemas-rust/Cargo.toml
@@ -1,18 +1,24 @@
 [package]
 name = "bonsol-schema"
-version.workspace = true
-description = "Bonsol types, schema definitions"
+version = "0.3.5"
+description = "Bonsol types and schema definitions"
 authors = ["anagram build team"]
 repository = "https://github.com/anagrambuild/bonsol"
 license = "MIT"
 edition = "2021"
+include = [
+    "src/**/*",
+    "Cargo.toml",
+    "build.rs",
+    "schema/**/*"
+]
 
 [dependencies]
 bytemuck = "1.7.2"
-flatbuffers = { workspace = true }
+flatbuffers = "24.3.25"
 num-derive = "0.3.3"
 num-traits = "0.2.15"
-thiserror = { workspace = true }
+thiserror = "1.0.57"
 
 [lints.rust]
 unused_imports = "allow"

--- a/schemas-rust/build.rs
+++ b/schemas-rust/build.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 
 fn main() {
     // Define schema directory and target directory for generated Rust code.
-    let schema_dir = Path::new("../schemas");
+    let schema_dir = Path::new("schema");
     let generated_src =
         PathBuf::from(env::var("GENERATED_CODE_DIR").unwrap_or_else(|_| "src".to_string()));
 

--- a/schemas-rust/schema/channel_instruction.fbs
+++ b/schemas-rust/schema/channel_instruction.fbs
@@ -1,0 +1,20 @@
+include "./execution_request_v1.fbs"; 
+include "./status_v1.fbs";
+include "./deploy_v1.fbs";
+include "./claim_v1.fbs";
+
+enum ChannelInstructionIxType: uint8 {
+  ExecuteV1 = 0,
+  StatusV1 = 1,
+  DeployV1 = 2,
+  ClaimV1 = 3,
+  //4 is reserved for InputSet which is removed
+}
+table ChannelInstruction{
+  ix_type: ChannelInstructionIxType;
+  execute_v1: [ubyte] (nested_flatbuffer: "ExecutionRequestV1");
+  status_v1: [ubyte] (nested_flatbuffer: "StatusV1");
+  deploy_v1: [ubyte] (nested_flatbuffer: "DeployV1");
+  claim_v1: [ubyte] (nested_flatbuffer: "ClaimV1");
+}
+root_type ChannelInstruction;

--- a/schemas-rust/schema/claim_v1.fbs
+++ b/schemas-rust/schema/claim_v1.fbs
@@ -1,0 +1,7 @@
+table ClaimV1 {
+  execution_id: string;
+  block_commitment: uint64;
+  //maybe some cool mpc decryption keys here or something
+}
+
+root_type ClaimV1;

--- a/schemas-rust/schema/deploy_v1.fbs
+++ b/schemas-rust/schema/deploy_v1.fbs
@@ -1,0 +1,13 @@
+include "./input_type.fbs";
+
+// programs are immutable and are identified by their id which is a digest of the program elf file
+table DeployV1 {
+  owner: [uint8]; //owner of the program duplicated here since its better to copy 32 bytes than to have to cow thew whole struct
+  image_id: string; //digest of the program elf file
+  program_name: string;
+  url: string; //url to the program elf file probbaly on ipfs/arweave/other 
+  size: uint64; //size of the program elf file
+  inputs: [ProgramInputType]; //loaded into the program in array order
+}
+
+root_type DeployV1;

--- a/schemas-rust/schema/execution_request_v1.fbs
+++ b/schemas-rust/schema/execution_request_v1.fbs
@@ -1,0 +1,29 @@
+include "./input_type.fbs";
+
+enum ProverVersion: uint16 {
+    DEFAULT = 0,
+    V1_0_1 = 1,
+    V1_2_1 = 9,
+}
+
+struct Account (force_align: 8) {
+  writable: uint8;
+  pubkey: [uint8:32];
+}
+
+table ExecutionRequestV1{
+  tip: uint64;
+  execution_id: string;
+  image_id: string;
+  callback_program_id: [uint8];
+  callback_instruction_prefix: [uint8];
+  forward_output: bool = false;
+  verify_input_hash: bool = true;
+  input: [Input];
+  input_digest: [uint8]; // sha256 of the input data, checked against journal digest
+  max_block_height: uint64; // max block height to accept prover commitment
+  callback_extra_accounts: [Account] (force_align: 8); // extra accounts to pass to callback program 
+  prover_version: ProverVersion = DEFAULT;
+}
+
+root_type ExecutionRequestV1;

--- a/schemas-rust/schema/input_type.fbs
+++ b/schemas-rust/schema/input_type.fbs
@@ -1,0 +1,21 @@
+enum ProgramInputType: uint8 {
+  Unknown = 0,
+  Public = 1,
+  Private = 2,
+  PublicProof = 3,
+}
+
+enum InputType: uint8 {
+  Unknown = 0,
+  PublicData = 1,
+  PublicAccountData = 3,
+  PublicUrl = 4,
+  Private = 5, // only used for local proving
+  PublicProof = 7,
+  PrivateLocal = 8
+}
+
+table Input {
+  input_type: InputType = 1;
+  data: [uint8];
+}

--- a/schemas-rust/schema/status_v1.fbs
+++ b/schemas-rust/schema/status_v1.fbs
@@ -1,0 +1,20 @@
+enum StatusTypes: uint8 {
+  Unknown = 0,
+  Queued = 1,
+  Claimed = 2,
+  Completed = 3,
+  Failed = 4,
+}
+
+table StatusV1{
+  execution_id: string;
+  status: StatusTypes;
+  proof: [uint8];
+  execution_digest: [uint8];
+  input_digest: [uint8];
+  committed_outputs: [uint8];
+  assumption_digest: [uint8];
+  exit_code_system: uint32;
+  exit_code_user: uint32;
+}
+root_type StatusV1;

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,15 +1,20 @@
 [package]
 name = "bonsol-sdk"
-version.workspace = true
+version = "0.3.5"
+description = "SDK for interacting with Bonsol protocol"
+authors = ["anagram build team"]
+repository = "https://github.com/anagrambuild/bonsol"
+license = "MIT"
 edition = "2021"
-publish = false          # Exclude local crates from licensing checks
 
 [dependencies]
 anyhow = "1.0.86"
 async-trait = "0.1.80"
 bincode = "1.3.3"
+bonsol-interface = "0.3.5"
+bonsol-schema = "0.3.5"
 bytes = "1.5.0"
-flatbuffers = { workspace = true }
+flatbuffers = "24.3.25"
 futures-util = "0.3.30"
 num-traits = "0.2.16"
 reqwest = { version = "0.11.26", features = [
@@ -18,14 +23,11 @@ reqwest = { version = "0.11.26", features = [
   "stream",
   "native-tls-vendored",
 ] }
-risc0-binfmt = { workspace = true }
-risc0-zkvm = { workspace = true }
+risc0-binfmt = "1.2.1"
+risc0-zkvm = { version = "1.2.1", features = ["prove"], default-features = false }
 serde = { version = "1.0.197" }
 serde_json = "1.0.104"
-solana-rpc-client = { workspace = true }
-solana-rpc-client-api = { workspace = true }
-solana-sdk = { workspace = true }
+solana-rpc-client = "~2.0"
+solana-rpc-client-api = "~2.0"
+solana-sdk = "~2.0"
 tokio = "1.36.0"
-
-bonsol-interface.workspace = true
-bonsol-schema.workspace = true


### PR DESCRIPTION
Prepares our crates for publishing to crates.io.

Crates to be published:
- [x] bonsol-schema
- [x] bonsol-interface
- [x] bonsol
- [x] bonsol-prover
- [x] bonsol-sdk

Not published:
- `bonsol-cli`: Let users download via `cargo install` or some other means
- `bonsol-node`: Runs as standalone service, distribute via executable
